### PR TITLE
Refine tag-like MFM parser to allow nesting

### DIFF
--- a/src/client/components/mfm.ts
+++ b/src/client/components/mfm.ts
@@ -118,10 +118,17 @@ export default Vue.component('misskey-flavored-markdown', {
 				}
 
 				case 'spin': {
-					const direction =
-						token.node.props.attr == 'left' ? 'reverse' :
-						token.node.props.attr == 'alternate' ? 'alternate' :
-						'normal';
+					function toDirection(attr: string): string {
+						switch (attr) {
+							case 'left': return 'reverse';
+							case 'right': return 'normal';
+							case 'alternate': return 'alternate';
+							default: return 'normal';
+						}
+					}
+
+					const attrs = token.node.props.attrs || [];
+					const direction = attrs.length > 0 ? toDirection(attrs[0]) : 'normal';
 					const style = this.$store.state.device.animatedMfm
 						? `animation: spin 1.5s linear infinite; animation-direction: ${direction};` : '';
 					return (createElement as any)('span', {

--- a/src/mfm/to-string.ts
+++ b/src/mfm/to-string.ts
@@ -13,6 +13,14 @@ export function toString(tokens: MfmForest | null, opts?: RestoreOptions): strin
 		return children.map(t => handlers[t.node.type](t, opts)).join('');
 	}
 
+	function tagHandler(name: string): (token: MfMTree, opts?: RestoreOptions) => string {
+		return (token, opts) => {
+			const attrs = token.node.props?.attrs;
+			const post = attrs ? ` ${attrs.join(' ')}` : '';
+			return `<${name}${post}>${appendChildren(token.children, opts)}</${name}>`;
+		};
+	}
+
 	const handlers: { [key: string]: (token: MfmTree, opts?: RestoreOptions) => string } = {
 		bold(token, opts) {
 			return `**${appendChildren(token.children, opts)}**`;
@@ -22,43 +30,27 @@ export function toString(tokens: MfmForest | null, opts?: RestoreOptions): strin
 			return `***${appendChildren(token.children, opts)}***`;
 		},
 
-		small(token, opts) {
-			return `<small>${appendChildren(token.children, opts)}</small>`;
-		},
+		small: tagHandler('small'),
 
 		strike(token, opts) {
 			return `~~${appendChildren(token.children, opts)}~~`;
 		},
 
-		italic(token, opts) {
-			return `<i>${appendChildren(token.children, opts)}</i>`;
-		},
+		italic: tagHandler('i'),
 
-		motion(token, opts) {
-			return `<motion>${appendChildren(token.children, opts)}</motion>`;
-		},
+		motion: tagHandler('motion'),
 
-		spin(token, opts) {
-			const attr = token.node.props?.attr;
-			const post = attr ? ` ${attr}` : '';
-			return `<spin${post}>${appendChildren(token.children, opts)}</spin>`;
-		},
+		spin: tagHandler('spin'),
 
-		jump(token, opts) {
-			return `<jump>${appendChildren(token.children, opts)}</jump>`;
-		},
+		jump: tagHandler('jump'),
 
-		flip(token, opts) {
-			return `<flip>${appendChildren(token.children, opts)}</flip>`;
-		},
+		flip: tagHandler('flip'),
 
 		blockCode(token) {
 			return `\`\`\`${token.node.props.lang || ''}\n${token.node.props.code}\n\`\`\`\n`;
 		},
 
-		center(token, opts) {
-			return `<center>${appendChildren(token.children, opts)}</center>`;
-		},
+		center: tagHandler('center'),
 
 		emoji(token) {
 			return (token.node.props.emoji ? token.node.props.emoji : `:${token.node.props.name}:`);

--- a/test/mfm.ts
+++ b/test/mfm.ts
@@ -1309,6 +1309,9 @@ describe('MFM', () => {
 		it('回転', () => {
 			assert.deepStrictEqual(toString(parse('<spin>回転</spin>')), '<spin>回転</spin>');
 		});
+		it('回転 ネスト', () => {
+			assert.deepStrictEqual(toString(parse('<spin><spin>回転</spin></spin>')), '<spin><spin>回転</spin></spin>');
+		});
 		it('右回転', () => {
 			assert.deepStrictEqual(toString(parse('<spin right>右回転</spin>')), '<spin right>右回転</spin>');
 		});

--- a/test/mfm.ts
+++ b/test/mfm.ts
@@ -261,9 +261,7 @@ describe('MFM', () => {
 				assert.deepStrictEqual(tokens, [
 					tree('spin', [
 						text('foo')
-					], {
-						attr: null
-					}),
+					], {}),
 				]);
 			});
 
@@ -272,9 +270,7 @@ describe('MFM', () => {
 				assert.deepStrictEqual(tokens, [
 					tree('spin', [
 						leaf('emoji', { name: 'foo' })
-					], {
-						attr: null
-					}),
+					], {}),
 				]);
 			});
 
@@ -284,24 +280,20 @@ describe('MFM', () => {
 					tree('spin', [
 						leaf('emoji', { name: 'foo' })
 					], {
-						attr: 'left'
+						attrs: ['left']
 					}),
 				]);
 			});
-/*
+
 			it('multi', () => {
 				const tokens = parse('<spin>:foo:</spin><spin>:foo:</spin>');
 				assert.deepStrictEqual(tokens, [
 					tree('spin', [
 						leaf('emoji', { name: 'foo' })
-					], {
-						attr: null
-					}),
+					], {}),
 					tree('spin', [
 						leaf('emoji', { name: 'foo' })
-					], {
-						attr: null
-					}),
+					], {}),
 				]);
 			});
 
@@ -311,15 +303,10 @@ describe('MFM', () => {
 					tree('spin', [
 						tree('spin', [
 							leaf('emoji', { name: 'foo' })
-						], {
-							attr: null
-						}),
-					], {
-						attr: null
-					}),
+						], {}),
+					], {}),
 				]);
 			});
-*/
 		});
 
 		it('jump', () => {


### PR DESCRIPTION
## Summary

タグ形式のMFM（ `<spin>` など）のパーサを修正し、ネストを可能にしました。
また、（結果的に）タグ内に複数行の入力を許すようになりました。

## Screenshot

```
<spin>a</spin><spin><spin alternate>a</spin></spin>
```

![spin](https://user-images.githubusercontent.com/16184855/87229864-a5379880-c3e6-11ea-891c-28372441b414.gif)

```
<spin>
a
b
c
</spin>
```

![rotate](https://user-images.githubusercontent.com/16184855/87229895-01022180-c3e7-11ea-9979-6d5d21810a1b.gif)
