### PR TITLE
Add '<animate>' syntax to MFM

### DIFF
--- a/src/client/components/mfm.ts
+++ b/src/client/components/mfm.ts
@@ -117,6 +117,34 @@ export default Vue.component('misskey-flavored-markdown', {
 					}, genEl(token.children));
 				}
 
+				case 'animate': {
+					const animations =
+						[ 'bounce'
+						, 'flash'
+						, 'pulse'
+						, 'rubberBand'
+						, 'headShake'
+						, 'swing'
+						, 'tada'
+						, 'wobble'
+						, 'jello'
+						, 'flip'
+						];
+					const attrs = token.node.props.attrs || [];
+					const animation = attrs.length > 0 ? attrs[0] : animations[Math.floor(animations.length * Math.random())];
+					const iteration = attrs.length > 1 ? attrs[1] : 'infinite';
+
+					return (createElement as any)('span', {
+						attrs: {
+							style: 'display: inline-block;'
+						},
+						directives: [this.$store.state.device.animatedMfm ? {
+							name: 'animate-css',
+							value: { classes: animation, iteration }
+						} : {}]
+					}, genEl(token.children));
+				}
+
 				case 'spin': {
 					function toDirection(attr: string): string {
 						switch (attr) {

--- a/src/mfm/language.ts
+++ b/src/mfm/language.ts
@@ -85,6 +85,7 @@ export const mfmLanguage = P.createLanguage({
 		r.italic,
 		r.strike,
 		r.motion,
+		r.animate,
 		r.spin,
 		r.jump,
 		r.flip,
@@ -122,6 +123,7 @@ export const mfmLanguage = P.createLanguage({
 		const xml = tag(r, 'motion');
 		return P.alt(paren, xml);
 	},
+	animate: r => tag(r, 'animate'),
 	spin: r => tag(r, 'spin'),
 	jump: r => tag(r, 'jump'),
 	flip: r => tag(r, 'flip'),

--- a/src/mfm/to-html.ts
+++ b/src/mfm/to-html.ts
@@ -54,6 +54,12 @@ export function toHtml(tokens: MfmForest | null, mentionedRemoteUsers: IMentione
 			return el;
 		},
 
+		animate(token) {
+			const el = doc.createElement('i');
+			appendChildren(token.children, el);
+			return el;
+		},
+
 		spin(token) {
 			const el = doc.createElement('i');
 			appendChildren(token.children, el);

--- a/src/mfm/to-string.ts
+++ b/src/mfm/to-string.ts
@@ -40,6 +40,8 @@ export function toString(tokens: MfmForest | null, opts?: RestoreOptions): strin
 
 		motion: tagHandler('motion'),
 
+		animate: tagHandler('animate'),
+
 		spin: tagHandler('spin'),
 
 		jump: tagHandler('jump'),

--- a/test/mfm.ts
+++ b/test/mfm.ts
@@ -255,6 +255,60 @@ describe('MFM', () => {
 			]);
 		});
 
+		describe('animate', () => {
+			it('text', () => {
+				const tokens = parse('<animate>foo</animate>');
+				assert.deepStrictEqual(tokens, [
+					tree('animate', [
+						text('foo')
+					], {}),
+				]);
+			});
+
+			it('emoji', () => {
+				const tokens = parse('<animate>:foo:</animate>');
+				assert.deepStrictEqual(tokens, [
+					tree('animate', [
+						leaf('emoji', { name: 'foo' })
+					], {}),
+				]);
+			});
+
+			it('with attr', () => {
+				const tokens = parse('<animate jello>:foo:</animate>');
+				assert.deepStrictEqual(tokens, [
+					tree('animate', [
+						leaf('emoji', { name: 'foo' })
+					], {
+						attrs: ['jello']
+					}),
+				]);
+			});
+
+			it('multi', () => {
+				const tokens = parse('<animate>:foo:</animate><animate>:foo:</animate>');
+				assert.deepStrictEqual(tokens, [
+					tree('animate', [
+						leaf('emoji', { name: 'foo' })
+					], {}),
+					tree('animate', [
+						leaf('emoji', { name: 'foo' })
+					], {}),
+				]);
+			});
+
+			it('nested', () => {
+				const tokens = parse('<animate><animate>:foo:</animate></animate>');
+				assert.deepStrictEqual(tokens, [
+					tree('animate', [
+						tree('animate', [
+							leaf('emoji', { name: 'foo' })
+						], {}),
+					], {}),
+				]);
+			});
+		});
+
 		describe('spin', () => {
 			it('text', () => {
 				const tokens = parse('<spin>foo</spin>');
@@ -1305,6 +1359,12 @@ describe('MFM', () => {
 		});
 		it('ビッグ＋', () => {
 			assert.deepStrictEqual(toString(parse('*** ビッグ＋ ***')), '*** ビッグ＋ ***');
+		});
+		it('アニメーション', () => {
+			assert.deepStrictEqual(toString(parse('<animate>アニメーション</animate>')), '<animate>アニメーション</animate>');
+		});
+		it('揺れるアニメーション', () => {
+			assert.deepStrictEqual(toString(parse('<animate wobble>アニメーション</animate>')), '<animate wobble>アニメーション</animate>');
 		});
 		it('回転', () => {
 			assert.deepStrictEqual(toString(parse('<spin>回転</spin>')), '<spin>回転</spin>');


### PR DESCRIPTION
## Summary

[Animate.css](https://animate.style/) のアニメーションが使える MFM 文法、 `<animate>` を実装しました。

一つ目の属性部分でアニメーション名を指定できます。指定しない場合、一部のアニメーションから（レンダリング時に）ランダムに選ばれます。

二つ目の属性部分でアニメーションの回数を指定できます。指定しない場合は無限に繰り返されます。

ランダムにアニメーションを選びつつアニメーションの回数を指定することができないのですが、そんなことしたい人間はおらんじゃろという話とそもそもランダムに選ぶ候補を無限に繰り返して自然なもので選んだのでまあこれでいいんじゃないでしょうかと思っています。

## ア

書いてから思ったけどランダムにアニメーションが選ばれるときに候補に書いたやつらが存在するかってロードされてる Animate.css のバージョンに依存しててかなりダメそう！どうしたらいいだろうか...

## Screenshot

```
<center><animate hinge 1>単位</animate></center>
```

![tani](https://user-images.githubusercontent.com/16184855/87971124-ce9ba700-caff-11ea-8106-02dafa1aea16.gif)


```
<animate flip>オイオイ</animate>
```

![oioi](https://user-images.githubusercontent.com/16184855/87970165-51236700-cafe-11ea-9b8e-3576d3f67584.gif)

```
<animate fadeInLeft 1>おはようございます！！</animate>
```

![ohayou](https://user-images.githubusercontent.com/16184855/87970143-4a94ef80-cafe-11ea-892b-8010b309e31b.gif)

