### PR TITLE
モデレーター権限で実行できる操作、閲覧できる情報を制限する

### DIFF
--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -578,7 +578,7 @@ export default Vue.extend({
 					}]
 					: []
 				),
-				...(this.appearNote.userId == this.$store.state.i.id || this.$store.state.i.isModerator || this.$store.state.i.isAdmin ? [
+				...(this.appearNote.userId == this.$store.state.i.id || this.$store.state.i.isAdmin ? [
 					null,
 					this.appearNote.userId == this.$store.state.i.id ? {
 						icon: faEdit,

--- a/src/server/api/endpoints/admin/delete-all-files-of-a-user.ts
+++ b/src/server/api/endpoints/admin/delete-all-files-of-a-user.ts
@@ -8,7 +8,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
+	requireAdmin: true,
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/admin/delete-logs.ts
+++ b/src/server/api/endpoints/admin/delete-logs.ts
@@ -5,7 +5,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
+	requireAdmin: true,
 };
 
 export default define(meta, async (ps) => {

--- a/src/server/api/endpoints/admin/drive/clean-remote-files.ts
+++ b/src/server/api/endpoints/admin/drive/clean-remote-files.ts
@@ -5,7 +5,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
+	requireAdmin: true,
 };
 
 export default define(meta, async (ps, me) => {

--- a/src/server/api/endpoints/admin/drive/cleanup.ts
+++ b/src/server/api/endpoints/admin/drive/cleanup.ts
@@ -7,7 +7,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
+	requireAdmin: true,
 };
 
 export default define(meta, async (ps, me) => {

--- a/src/server/api/endpoints/admin/drive/files.ts
+++ b/src/server/api/endpoints/admin/drive/files.ts
@@ -7,7 +7,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: false as const,
-	requireModerator: true,
+	requireAdmin: true,
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/admin/drive/show-file.ts
+++ b/src/server/api/endpoints/admin/drive/show-file.ts
@@ -8,7 +8,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
+	requireAdmin: true,
 
 	params: {
 		fileId: {

--- a/src/server/api/endpoints/admin/logs.ts
+++ b/src/server/api/endpoints/admin/logs.ts
@@ -7,7 +7,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
+	requireAdmin: true,
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/admin/relays/add.ts
+++ b/src/server/api/endpoints/admin/relays/add.ts
@@ -11,7 +11,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true as const,
+	requireAdmin: true as const,
 
 	params: {
 		inbox: {

--- a/src/server/api/endpoints/admin/relays/list.ts
+++ b/src/server/api/endpoints/admin/relays/list.ts
@@ -9,7 +9,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true as const,
+	requireAdmin: true as const,
 
 	params: {
 	},

--- a/src/server/api/endpoints/admin/relays/remove.ts
+++ b/src/server/api/endpoints/admin/relays/remove.ts
@@ -10,7 +10,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true as const,
+	requireAdmin: true as const,
 
 	params: {
 		inbox: {

--- a/src/server/api/endpoints/admin/reset-password.ts
+++ b/src/server/api/endpoints/admin/reset-password.ts
@@ -13,7 +13,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
+	requireAdmin: true,
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/admin/show-moderation-logs.ts
+++ b/src/server/api/endpoints/admin/show-moderation-logs.ts
@@ -8,7 +8,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
+	requireAdmin: true,
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/admin/show-user.ts
+++ b/src/server/api/endpoints/admin/show-user.ts
@@ -11,7 +11,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
+	requireAdmin: true,
 
 	params: {
 		userId: {

--- a/src/server/api/endpoints/admin/show-users.ts
+++ b/src/server/api/endpoints/admin/show-users.ts
@@ -6,7 +6,7 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
+	requireAdmin: true,
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/notes/delete.ts
+++ b/src/server/api/endpoints/notes/delete.ts
@@ -57,7 +57,7 @@ export default define(meta, async (ps, user) => {
 		throw e;
 	});
 
-	if (!user.isAdmin && !user.isModerator && (note.userId !== user.id)) {
+	if (!user.isAdmin && (note.userId !== user.id)) {
 		throw new ApiError(meta.errors.accessDenied);
 	}
 


### PR DESCRIPTION
## Summary

モデレーター権限で行える操作を制限した（Admin だけに限定した）。

Cisskey だと絵文字の追加や編集する関係で権限の付与が特殊になっている。この状態だと、インスタンスや自分以外のユーザーに関連する情報が必要以上に取得でき、大きな問題になる可能性が（ちょびっとだけ）ある。

（（絵文字追加編集bot?とかができるまでの）応急処置的な位置付けであり、諸々へのページへアクセスする経路？（↓）はそのまま残してある。）

![ss_2020-07-27_04-00-34](https://user-images.githubusercontent.com/37328795/88487295-c55a8080-cfbe-11ea-85dc-d94cc1490c01.png)

