### PR TITLE
一般ユーザーが絵文字を編集できるように

### DIFF
--- a/src/client/app.vue
+++ b/src/client/app.vue
@@ -57,9 +57,12 @@
 					</component>
 				</template>
 				<div class="divider"></div>
-				<button class="item _button" :class="{ active: $route.path === '/instance' || $route.path.startsWith('/instance/') }" v-if="$store.getters.isSignedIn && ($store.state.i.isAdmin || $store.state.i.isModerator)" @click="oepnInstanceMenu">
+				<button class="item _button" :class="{ active: $route.path === '/instance' || ($route.path.startsWith('/instance/') && !($route.path === '/instance/emojis')) }" v-if="$store.getters.isSignedIn && ($store.state.i.isAdmin || $store.state.i.isModerator)" @click="oepnInstanceMenu">
 					<fa :icon="faServer" fixed-width/><span class="text">{{ $t('instance') }}</span>
 				</button>
+				<router-link class="item" active-class="active" to="/instance/emojis" v-if="$store.getters.isSignedIn">
+					<fa :icon="faLaugh" fixed-width/><span class="text">{{ $t('customEmojis') }}</span>
+				</router-link>
 				<button class="item _button" @click="more">
 					<fa :icon="faEllipsisH" fixed-width/><span class="text">{{ $t('more') }}</span>
 					<i v-if="otherNavItemIndicated"><fa :icon="faCircle"/></i>

--- a/src/server/api/endpoints/admin/emoji/add.ts
+++ b/src/server/api/endpoints/admin/emoji/add.ts
@@ -17,7 +17,6 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
 
 	params: {
 		fileId: {

--- a/src/server/api/endpoints/admin/emoji/copy.ts
+++ b/src/server/api/endpoints/admin/emoji/copy.ts
@@ -12,7 +12,6 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
 
 	params: {
 		emojiId: {

--- a/src/server/api/endpoints/admin/emoji/list.ts
+++ b/src/server/api/endpoints/admin/emoji/list.ts
@@ -12,7 +12,6 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
 
 	params: {
 		limit: {

--- a/src/server/api/endpoints/admin/emoji/remove.ts
+++ b/src/server/api/endpoints/admin/emoji/remove.ts
@@ -14,7 +14,6 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
 
 	params: {
 		id: {

--- a/src/server/api/endpoints/admin/emoji/update.ts
+++ b/src/server/api/endpoints/admin/emoji/update.ts
@@ -13,7 +13,6 @@ export const meta = {
 	tags: ['admin'],
 
 	requireCredential: true as const,
-	requireModerator: true,
 
 	params: {
 		id: {


### PR DESCRIPTION
## Summary

Moderator, Admin 権限を持たないユーザーも絵文字を編集できるようにした。

また、一般ユーザーが絵文字編集ページへアクセスしやすいように、サイドバーにボタンを追加した。
![ss_2020-07-27_06-07-07](https://user-images.githubusercontent.com/37328795/88489625-466e4380-cfd0-11ea-91ad-1dbb8177d9c0.png)

