### PR TITLE
時刻部分に絶対時刻を表示するツールチップを追加

### DIFF
--- a/src/client/components/note-header.vue
+++ b/src/client/components/note-header.vue
@@ -102,6 +102,10 @@ export default Vue.extend({
 		> .localOnly {
 			margin-left: 8px;
 		}
+
+		> .created-at {
+			-webkit-touch-callout: none;
+		}
 	}
 }
 </style>

--- a/src/client/components/time.vue
+++ b/src/client/components/time.vue
@@ -1,5 +1,5 @@
 <template>
-<time class="mk-time" :title="absolute">
+<time class="mk-time" v-tooltip="typeof time == 'string' ? new Date(time).toLocaleString() : time.toLocaleString()">
 	<span v-if="mode == 'relative'">{{ relative }}</span>
 	<span v-if="mode == 'absolute'">{{ absolute }}</span>
 	<span v-if="mode == 'detail'">{{ absolute }} ({{ relative }})</span>


### PR DESCRIPTION
## Summary

時刻部分にカーソルホバーで絶対時刻表示

![ss_2020-07-27_08-31-45](https://user-images.githubusercontent.com/37328795/88492219-0749ed80-cfe4-11ea-9047-d48dd702f698.png)


### なぜやった？
既に、PC のブラウザからアクセスした場合に、ノートの時刻表示にカーソルをホバーすると絶対時刻が表示される。しかし、スマホからでは絶対時刻を確認することができないという問題があったから。


resolve #14
