### PR TITLE
ノートの時刻表示を 相対/絶対/相対+絶対 で切りかえ可能にした

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -1095,3 +1095,7 @@ _notification:
   yourFollowRequestAccepted: "Your follow request was accepted"
   youWereInvitedToGroup: "Invited to group"
 
+_timestampFormats:
+  relative: Relative
+  absolute: Absolute
+  detail: Absolute + Relative

--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -518,6 +518,8 @@ enableInfiniteScroll: "Enable infinite scrolling"
 visibility: "Visiblility"
 poll: "Poll"
 useCw: "Hide content"
+timestampFormat: "Timestamp Format"
+
 _theme:
   explore: "Explore Themes"
   install: "Install theme"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -517,6 +517,7 @@ enableInfiniteScroll: "自動でもっと見る"
 visibility: "公開範囲"
 poll: "アンケート"
 useCw: "内容を隠す"
+timestampFormat: "タイムスタンプの形式"
 
 _theme:
   explore: "テーマを探す"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1128,3 +1128,7 @@ _notification:
   yourFollowRequestAccepted: "フォローリクエストが承認されました"
   youWereInvitedToGroup: "グループに招待されました"
 
+_timestampFormats:
+  relative: 相対
+  absolute: 絶対
+  detail: 絶対 + 相対

--- a/src/client/components/note-header.vue
+++ b/src/client/components/note-header.vue
@@ -10,7 +10,7 @@
 	<div class="info">
 		<span class="mobile" v-if="note.viaMobile"><fa :icon="faMobileAlt"/></span>
 		<router-link class="created-at" :to="note | notePage">
-			<mk-time :time="note.createdAt" :mode="$store.state.device.timestampFormat"/>
+			<mk-time :time="note.createdAt"/>
 		</router-link>
 		<span class="visibility" v-if="note.visibility !== 'public'">
 			<fa v-if="note.visibility === 'home'" :icon="faHome"/>

--- a/src/client/components/note-header.vue
+++ b/src/client/components/note-header.vue
@@ -10,7 +10,7 @@
 	<div class="info">
 		<span class="mobile" v-if="note.viaMobile"><fa :icon="faMobileAlt"/></span>
 		<router-link class="created-at" :to="note | notePage">
-			<mk-time :time="note.createdAt"/>
+			<mk-time :time="note.createdAt" :mode="$store.state.device.timestampFormat"/>
 		</router-link>
 		<span class="visibility" v-if="note.visibility !== 'public'">
 			<fa v-if="note.visibility === 'home'" :icon="faHome"/>

--- a/src/client/components/time.vue
+++ b/src/client/components/time.vue
@@ -17,7 +17,13 @@ export default Vue.extend({
 		},
 		mode: {
 			type: String,
-			default: 'relative'
+			default: function(m: string) {
+				if (m === undefined) {
+					return this.$store.state.device.timestampFormat;
+				} else {
+					return m;
+				}
+			}
 		}
 	},
 	data() {

--- a/src/client/pages/preferences/index.vue
+++ b/src/client/pages/preferences/index.vue
@@ -73,7 +73,7 @@
 		<div class="_content">
 			<mk-select v-model="timestampFormat">
 				<template #label>{{ $t('timestampFormat') }}</template>
-				<option v-for="tf in timestampFormats" :value="tf" :key="tf">{{ tf }}</option>
+				<option v-for="tf in timestampFormats" :value="tf" :key="tf">{{ $t('_timestampFormats.' + tf) }}</option>
 			</mk-select>
 		</div>
 		<div class="_content">

--- a/src/client/pages/preferences/index.vue
+++ b/src/client/pages/preferences/index.vue
@@ -71,6 +71,12 @@
 			<mk-switch v-model="disablePagesScript">{{ $t('disablePagesScript') }}</mk-switch>
 		</div>
 		<div class="_content">
+			<mk-select v-model="timestampFormat">
+				<template #label>{{ $t('timestampFormat') }}</template>
+				<option v-for="tf in timestampFormats" :value="tf" :key="tf">{{ tf }}</option>
+			</mk-select>
+		</div>
+		<div class="_content">
 			<mk-select v-model="lang">
 				<template #label>{{ $t('uiLanguage') }}</template>
 
@@ -120,6 +126,12 @@ const sounds = [
 	'noizenecio/kick_gaba',
 ];
 
+const timestampFormats = [
+	'relative',
+	'absolute',
+	'detail'
+];
+
 export default Vue.extend({
 	metaInfo() {
 		return {
@@ -143,6 +155,7 @@ export default Vue.extend({
 			lang: localStorage.getItem('lang'),
 			fontSize: localStorage.getItem('fontSize'),
 			sounds,
+			timestampFormats,
 			faImage, faCog, faMusic, faPlay, faVolumeUp, faVolumeMute
 		}
 	},
@@ -227,6 +240,11 @@ export default Vue.extend({
 			get() {
 				return this.sfxVolume === 0 ? faVolumeMute : faVolumeUp;
 			}
+		},
+
+		timestampFormat: {
+			get() { return this.$store.state.device.timestampFormat; },
+			set(value) { this.$store.commit('device/set', { key: 'timestampFormat', value }); }
 		}
 	},
 

--- a/src/client/pages/user/index.vue
+++ b/src/client/pages/user/index.vue
@@ -52,7 +52,7 @@
 			</dl>
 			<dl class="field">
 				<dt class="name"><fa :icon="faCalendarAlt" fixed-width/> {{ $t('registeredDate') }}</dt>
-				<dd class="value">{{ new Date(user.createdAt).toLocaleString() }} (<mk-time :time="user.createdAt"/>)</dd>
+				<dd class="value">{{ new Date(user.createdAt).toLocaleString() }} (<mk-time :time="user.createdAt" mode="relative"/>)</dd>
 			</dl>
 		</div>
 		<div class="fields" v-if="user.fields.length > 0">


### PR DESCRIPTION
## Summary

![ss_2020-07-27_08-48-19](https://user-images.githubusercontent.com/37328795/88492570-95bf6e80-cfe6-11ea-9690-0dabb79457fa.png)

![ss_2020-07-27_08-48-31](https://user-images.githubusercontent.com/37328795/88492572-9952f580-cfe6-11ea-8264-a7f41f7653cd.png)

![ss_2020-07-27_08-48-45](https://user-images.githubusercontent.com/37328795/88492576-9bb54f80-cfe6-11ea-8293-892aa7f0c5c9.png)

![ss_2020-07-27_08-47-58](https://user-images.githubusercontent.com/37328795/88492578-9e17a980-cfe6-11ea-8cab-ccd856e69abf.png)

- `/src/client/components/time.vue` の `mode` がデフォで `relative` と設定されているだけで変更できる仕組みがみつからなかった
- クライアント設定から時刻表示形式を変更できるようにした
- relative とかを多言語対応させようかと思ったけど、今の僕の知識が無理だった（すまん！
- いろいろと雑ですまん！　（つっこんでくれると嬉しい！
