### PR TITLE
Change: リアクションピッカーを開いたとき、絵文字入力欄にフォーカスするように（ #22 ）

### DIFF
--- a/src/client/components/reaction-picker.vue
+++ b/src/client/components/reaction-picker.vue
@@ -4,7 +4,7 @@
 		<div class="buttons" ref="buttons" :class="{ showFocus }">
 			<button class="_button" v-for="(reaction, i) in rs" :key="reaction" @click="react(reaction)" :tabindex="i + 1" :title="reaction" v-particle><x-reaction-icon :reaction="reaction"/></button>
 		</div>
-		<input class="text" v-model.trim="text" :placeholder="$t('enterEmoji')" @keyup.enter="reactText" @input="tryReactText" v-autocomplete="{ model: 'text' }">
+		<input class="text" v-model.trim="text" :placeholder="$t('enterEmoji')" @keyup.enter="reactText" @keyup.esc="close" @input="tryReactText" v-autocomplete="{ model: 'text' }" ref="textEmojiName">
 	</div>
 </x-popup>
 </template>
@@ -76,6 +76,7 @@ export default Vue.extend({
 
 	mounted() {
 		this.focus = 0;
+		this.$nextTick(() => this.$refs.textEmojiName.focus());
 	},
 
 	methods: {


### PR DESCRIPTION
## Summary

- リアクションピッカーを開くと同時に、絵文字名の入力欄にフォーカスするようにした。

## 気になるところ
- スマホで閲覧しているとき、リアクションピッカー開いたらキーボードが自動的に表示されるの邪魔かもしれない？
- （リアクションピッカー開いた直後は input にフォーカスされるので）リアクションフォームに関するキーボードショートカットが効かなくなる
    - ESC でピッカー閉じるだけは効くようにした
    - https://github.com/Cisskey/misskey/blob/cisskey/src/docs/keyboard-shortcut.ja-JP.md


Resolve #22 
