### PR TITLE
.config を Docker イメージに含めないようにする

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ elasticsearch/
 node_modules/
 redis/
 files
+.config
 
 .devcontainer
 docker-compose.dev.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - .config/docker_web.env
     volumes:
       - ./files:/misskey/files
+      - ./.config:/misskey/.config:ro
 
   redis:
     restart: always


### PR DESCRIPTION
## Summary

`.config` を Docker イメージに含めないようにして、 Docker イメージは外部に置けるようにする