### PR TITLE
Fix: manifest.json にアクセスする際、Cookie を含めるように #35

### DIFF
--- a/src/server/web/views/base.pug
+++ b/src/server/web/views/base.pug
@@ -15,7 +15,7 @@ html
 		meta(name='viewport' content='width=device-width, initial-scale=1')
 		link(rel='icon' href= icon || '/favicon.ico')
 		link(rel='apple-touch-icon' href= icon || '/apple-touch-icon.png')
-		link(rel='manifest' href='/manifest.json')
+		link(rel='manifest' href='/manifest.json' crossorigin='use-credentials')
 		link(rel='prefetch' href='https://xn--931a.moe/assets/info.jpg')
 		link(rel='prefetch' href='https://xn--931a.moe/assets/not-found.jpg')
 		link(rel='prefetch' href='https://xn--931a.moe/assets/error.jpg')


### PR DESCRIPTION
## Summary

manifest.json にアクセスする際、Cookie を含めるようにした。


Resolve #35 