### PR TITLE
投稿フォームを固定しているとき、投稿後もカーソルをその場に残すように

### DIFF
--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -593,6 +593,9 @@ export default Vue.extend({
 			}).catch(err => {
 			}).then(() => {
 				this.posting = false;
+				this.$nextTick(() => {
+					this.focus();
+				});
 			});
 
 			if (this.text && this.text != '') {

--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -446,6 +446,7 @@ export default Vue.extend({
 		},
 
 		onKeydown(e) {
+			if (e.which === 27 && this.$store.state.device.showFixedPostForm) this.$refs.text.blur();
 			if ((e.which == 10 || e.which == 13) && (e.ctrlKey || e.metaKey) && this.canPost) this.post();
 		},
 

--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -594,9 +594,7 @@ export default Vue.extend({
 			}).catch(err => {
 			}).then(() => {
 				this.posting = false;
-				this.$nextTick(() => {
-					this.focus();
-				});
+				if (this.fixed) this.$nextTick(() => this.focus());
 			});
 
 			if (this.text && this.text != '') {

--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -446,7 +446,7 @@ export default Vue.extend({
 		},
 
 		onKeydown(e) {
-			if (e.which === 27 && this.$store.state.device.showFixedPostForm) this.$refs.text.blur();
+			if (e.which === 27 && this.fixed) this.$refs.text.blur();
 			if ((e.which == 10 || e.which == 13) && (e.ctrlKey || e.metaKey) && this.canPost) this.post();
 		},
 


### PR DESCRIPTION
## Summary

投稿後も投稿フォームにカーソル（フォーカス）を残すようにした。
画面上部の投稿フォームにフォーカスしているとき、ESCキーでフォーカスを外せるようにした。

nキーで、画面上部に固定された投稿フォームにフォーカスするのは実装しなかった。
→TLをスクロールすると投稿フォームもスクロールされる仕様だから & 面倒っぽい気がしたので

Resolve #5 