### PR TITLE
リアクションピッカーのinputにおいて、先頭にコロンを付けなくても良いようにした

### DIFF
--- a/src/client/components/reaction-picker.vue
+++ b/src/client/components/reaction-picker.vue
@@ -4,7 +4,7 @@
 		<div class="buttons" ref="buttons" :class="{ showFocus }">
 			<button class="_button" v-for="(reaction, i) in rs" :key="reaction" @click="react(reaction)" :tabindex="i + 1" :title="reaction" v-particle><x-reaction-icon :reaction="reaction"/></button>
 		</div>
-		<input class="text" v-model.trim="text" :placeholder="$t('enterEmoji')" @keyup.enter="reactText" @keyup.esc="close" @input="tryReactText" v-autocomplete="{ model: 'text' }" ref="textEmojiName">
+		<input class="text" v-model.trim="text" :placeholder="$t('enterEmoji')" @keyup.enter="reactText" @keyup.esc="close" @input="tryReactText" v-autocomplete="{ model: 'text', type: 'reactionPicker' }" ref="textEmojiName">
 	</div>
 </x-popup>
 </template>

--- a/src/client/directives/autocomplete.ts
+++ b/src/client/directives/autocomplete.ts
@@ -24,6 +24,7 @@ class Autocomplete {
 	private currentType: string;
 	private opts: {
 		model: string;
+		type?: string;
 	};
 	private opening: boolean;
 
@@ -33,6 +34,10 @@ class Autocomplete {
 
 	private set text(text: string) {
 		this.vm[this.opts.model] = text;
+	}
+
+	private get type(): string {
+		return this.opts.type;
 	}
 
 	/**
@@ -76,7 +81,7 @@ class Autocomplete {
 
 		const mentionIndex = text.lastIndexOf('@');
 		const hashtagIndex = text.lastIndexOf('#');
-		const emojiIndex = text.lastIndexOf(':');
+		const emojiIndex = (this.type === 'reactionPicker') ? 0 : text.lastIndexOf(':');
 
 		const max = Math.max(
 			mentionIndex,
@@ -114,7 +119,7 @@ class Autocomplete {
 		}
 
 		if (isEmoji && !opened) {
-			const emoji = text.substr(emojiIndex + 1);
+			const emoji = (this.type === 'reactionPicker') ? (text.startsWith(':') ? text.substr(1) : text) : text.substr(emojiIndex + 1);
 			if (!emoji.includes(' ')) {
 				this.open('emoji', emoji);
 				opened = true;


### PR DESCRIPTION
## Summary

リアクションピッカーで絵文字名を入力するとき、コロンを必要としないオプションを追加した。
デフォルトでは、コロンを必要とする。

## ？
autocomplete が reaction-picker から呼び出されているかどうかをいい感じに判別する方法がなかった。