### PR TITLE
検索機能の強化（from, to, since, until, file, poll cw）

### DIFF
--- a/src/models/entities/user.ts
+++ b/src/models/entities/user.ts
@@ -217,3 +217,5 @@ export interface ILocalUser extends User {
 export interface IRemoteUser extends User {
 	host: string;
 }
+
+export type IUser = ILocalUser | IRemoteUser;

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -86,6 +86,7 @@ export default define(meta, async (ps, me) => {
 		const pollsRegex = /^(poll|polls)$/i;
 		const cwRegex = /cw/i;
 		const filterRegex = /^filter:(\w+)$/;
+		const excludeRegex = /^-([\w:@.-]+)$/;
 		const tokens = ps.query.trim().match(/(?:[^\s"']+|['"][^'"]*["'])+/g);
 		if (tokens == null) return [];
 		for (let token of tokens) {
@@ -138,14 +139,13 @@ export default define(meta, async (ps, me) => {
 
 			const matchFilter = token.match(filterRegex);
 			if (matchFilter) {
-				const replacedWord = token.replace(/^filter:/, '');
-				const matchPolls = replacedWord.match(pollsRegex);
+				const matchPolls = matchFilter[1].match(pollsRegex);
 				if (matchPolls) {
 					withPolls = true;
 					continue;
 				}
 
-				const matchCw = replacedWord.match(cwRegex);
+				const matchCw = matchFilter[1].match(cwRegex);
 				if (matchCw) {
 					withCw = true;
 					continue;
@@ -153,10 +153,9 @@ export default define(meta, async (ps, me) => {
 				return [];
 			}
 
-			const matchExcludeWord = token.match(/^-/);
+			const matchExcludeWord = token.match(excludeRegex);
 			if (matchExcludeWord) {
-				const replacedExcludeWord = token.replace(/^-/, '');
-				const matchFrom = replacedExcludeWord.match(fromRegex);
+				const matchFrom = matchExcludeWord[1].match(fromRegex);
 				if (matchFrom) {
 					const user = await getUser(matchFrom[1], matchFrom[2]);
 					if (user == null) {
@@ -167,7 +166,7 @@ export default define(meta, async (ps, me) => {
 					}
 				}
 
-				const matchToUser = replacedExcludeWord.match(toRegex);
+				const matchToUser = matchExcludeWord[1].match(toRegex);
 				if (matchToUser) {
 					const user = await getUser(matchToUser[1], matchToUser[2]);
 					if (user == null) {
@@ -178,16 +177,15 @@ export default define(meta, async (ps, me) => {
 					}
 				}
 
-				const matchFilter = replacedExcludeWord.match(filterRegex);
+				const matchFilter = matchExcludeWord[1].match(filterRegex);
 				if (matchFilter) {
-					const replacedFilterWord = replacedExcludeWord.replace(/^filter:/, '');
-					const matchPolls = replacedFilterWord.match(pollsRegex);
+					const matchPolls = matchFilter[1].match(pollsRegex);
 					if (matchPolls) {
 						withPolls = false;
 						continue;
 					}
 
-					const matchCw = replacedFilterWord.match(cwRegex);
+					const matchCw = matchFilter[1].match(cwRegex);
 					if (matchCw) {
 						withCw = false;
 						continue;
@@ -195,7 +193,7 @@ export default define(meta, async (ps, me) => {
 					return [];
 				}
 
-				const matchFile = replacedExcludeWord.match(/^filetype:(\w+)$/);
+				const matchFile = matchExcludeWord[1].match(/^filetype:(\w+)$/);
 				if (matchFile) {
 					if (matchFile[1] === 'all') {
 						withFiles = false;
@@ -205,7 +203,7 @@ export default define(meta, async (ps, me) => {
 					}
 				}
 
-				excludeWords.push(replacedExcludeWord);
+				excludeWords.push(matchExcludeWord[1]);
 				continue;
 			}
 			words.push(token);

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -177,10 +177,10 @@ export default define(meta, async (ps, me) => {
 			query.andWhere('note.fileIds != :fileId', { fileId: '{}' });
 		}
 		if (since) {
-			query.andWhere('note.createdAt > :since', { since: since });
+			query.andWhere('note.createdAt >= :since', { since: since });
 		}
 		if (until) {
-			query.andWhere('note.createdAt < :until', { until: until });
+			query.andWhere('note.createdAt <= :until', { until: until });
 		}
 		if (excludeWords.length > 0) {
 			query.andWhere(new Brackets(qb => {

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -222,18 +222,22 @@ export default define(meta, async (ps, me) => {
 				}
 			}));
 		}
-		if (withFiles == true) {
-			query.andWhere('note.fileIds != :fileId', { fileId: '{}' });
-		} else if (withFiles == false) {
-			query.andWhere('note.fileIds = :fileId', { fileId: '{}' });
+		if (withFiles != null) {
+			if (withFiles) {
+				query.andWhere('note.fileIds != :fileId', { fileId: '{}' });
+			} else {
+				query.andWhere('note.fileIds = :fileId', { fileId: '{}' });
+			}
 		}
 		if (withPolls != null) {
 			query.andWhere('note.hasPoll = :withPolls', { withPolls: withPolls });
 		}
-		if (withCw == true) {
-			query.andWhere('note.cw IS NOT NULL');
-		} else if (withCw == false) {
-			query.andWhere('note.cw IS NULL');
+		if (withCw != null) {
+			if (withCw) {
+				query.andWhere('note.cw IS NOT NULL');
+			} else {
+				query.andWhere('note.cw IS NULL');
+			}
 		}
 		if (since) {
 			query.andWhere('note.createdAt >= :since', { since: since });

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -204,9 +204,11 @@ export default define(meta, async (ps, me) => {
 					}
 				}
 
+				if (!safeForSql(matchExcludeWord[1])) return [];
 				excludeWords.push(matchExcludeWord[1]);
 				continue;
 			}
+			if (!safeForSql(token)) return [];
 			words.push(token);
 		}
 
@@ -216,7 +218,6 @@ export default define(meta, async (ps, me) => {
 		if (toUsers.length > 0) {
 			query.andWhere(new Brackets(qb => {
 				for (const toUser of toUsers) {
-					if (!safeForSql(toUser.id)) return;
 					qb.andWhere(':toUser.id = ANY (note.mentions)', { toUser: toUser.id });
 				}
 			}));
@@ -244,7 +245,6 @@ export default define(meta, async (ps, me) => {
 			query.andWhere(new Brackets(qb => {
 				let count = 0;
 				for (const excludeWord of excludeWords) {
-					if (!safeForSql(excludeWord)) return;
 					qb.andWhere(`note.text NOT ILIKE :excludeWord_${count}`, { [`excludeWord_${count}`]: `%${excludeWord}%` });
 					count++;
 				}
@@ -270,7 +270,6 @@ export default define(meta, async (ps, me) => {
 			query.andWhere(new Brackets(qb => {
 				let count = 0;
 				for (const word of words) {
-					if (!safeForSql(word)) return;
 					qb.andWhere(`note.text ILIKE :word_${count}`, { [`word_${count}`]: `%${word}%` });
 					count++;
 				}

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -91,7 +91,7 @@ export default define(meta, async (ps, me) => {
 				}
 			}
 
-			const matchFile = token.match(/^file:(\w+)$/);
+			const matchFile = token.match(/^filetype:(\w+)$/);
 			if (matchFile) {
 				if (matchFile[1] === 'all') {
 					withFiles = true;

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -155,8 +155,8 @@ export default define(meta, async (ps, me) => {
 
 			const matchExcludeWord = token.match(/^-/);
 			if (matchExcludeWord) {
-				const replacedWord = token.replace(/^-/, '');
-				const matchFrom = replacedWord.match(fromRegex);
+				const replacedExcludeWord = token.replace(/^-/, '');
+				const matchFrom = replacedExcludeWord.match(fromRegex);
 				if (matchFrom) {
 					const user = await getUser(matchFrom[1], matchFrom[2]);
 					if (user == null) {
@@ -167,7 +167,7 @@ export default define(meta, async (ps, me) => {
 					}
 				}
 
-				const matchToUser = replacedWord.match(toRegex);
+				const matchToUser = replacedExcludeWord.match(toRegex);
 				if (matchToUser) {
 					const user = await getUser(matchToUser[1], matchToUser[2]);
 					if (user == null) {
@@ -178,7 +178,18 @@ export default define(meta, async (ps, me) => {
 					}
 				}
 
-				excludeWords.push(replacedWord);
+				const matchFilter = replacedExcludeWord.match(filterRegex);
+				if (matchFilter) {
+					const replacedFilterWord = replacedExcludeWord.replace(/^filter:/, '');
+					const matchCw = replacedFilterWord.match(cwRegex);
+					if (matchCw) {
+						withCw = false;
+						continue;
+					}
+					return [];
+				}
+
+				excludeWords.push(replacedExcludeWord);
 				continue;
 			}
 			words.push(token);

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -72,6 +72,7 @@ export default define(meta, async (ps, me) => {
 
 		let from: IUser | null  = null;
 		let words: string = '';
+		let withFiles = false;
 		const tokens = ps.query.trim().split(/\s+/);
 		for (const token of tokens) {
 			const matchFrom = token.match(/^from:@?([\w-]+)(?:@([\w.-]+))?$/);
@@ -86,11 +87,24 @@ export default define(meta, async (ps, me) => {
 				from = user;
 				continue;
 			}
+
+			const matchFile = token.match(/^file:(\w+)$/);
+			if (matchFile) {
+				if (matchFile[1] === 'all') {
+					withFiles = true;
+					continue;
+				} else {
+					return [];
+				}
+			}
 			words += token;
 		}
 
 		if (from) {
 			query.andWhere('note.userId = :userId', { userId: from.id });
+		}
+		if (withFiles) {
+			query.andWhere('note.fileIds != :fileId', { fileId: '{}' });
 		}
 		if (words.length > 0) {
 			query.andWhere('note.text ILIKE :q', { q: `%${words}%` });

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -78,6 +78,7 @@ export default define(meta, async (ps, me) => {
 		const excludeWords: string[] = [];
 		let withFiles = false;
 		let since: Date | null = null;
+		let until: Date | null = null;
 		const fromRegex = /^from:@?([\w-]+)(?:@([\w.-]+))?$/;
 		const toRegex = /^to:@?([\w-]+)(?:@([\w.-]+))?$/;
 		const tokens = ps.query.trim().match(/(?:[^\s"']+|['"][^'"]*["'])+/g);
@@ -120,6 +121,13 @@ export default define(meta, async (ps, me) => {
 			if (matchSince) {
 				since = new Date(`${matchSince[1]} 00:00:00 +0900`);
 				if (isNaN(since.getTime())) return [];
+				continue;
+			}
+
+			const matchUntil = token.match(/^until:(\d{4}-\d{1,2}-\d{1,2})/);
+			if (matchUntil) {
+				until = new Date(`${matchUntil[1]} 23:59:59 +0900`);
+				if (isNaN(until.getTime())) return [];
 				continue;
 			}
 
@@ -170,6 +178,9 @@ export default define(meta, async (ps, me) => {
 		}
 		if (since) {
 			query.andWhere('note.createdAt > :since', { since: since });
+		}
+		if (until) {
+			query.andWhere('note.createdAt < :until', { until: until });
 		}
 		if (excludeWords.length > 0) {
 			query.andWhere(new Brackets(qb => {

--- a/src/server/api/endpoints/notes/search.ts
+++ b/src/server/api/endpoints/notes/search.ts
@@ -87,6 +87,7 @@ export default define(meta, async (ps, me) => {
 		const cwRegex = /cw/i;
 		const filterRegex = /^filter:(\w+)$/;
 		const excludeRegex = /^-([\w:@.-]+)$/;
+		const filetypeRegex = /^filetype:(\w+)$/;
 		const tokens = ps.query.trim().match(/(?:[^\s"']+|['"][^'"]*["'])+/g);
 		if (tokens == null) return [];
 		for (let token of tokens) {
@@ -102,9 +103,9 @@ export default define(meta, async (ps, me) => {
 				}
 			}
 
-			const matchFile = token.match(/^filetype:(\w+)$/);
-			if (matchFile) {
-				if (matchFile[1] === 'all') {
+			const matchFileType = token.match(filetypeRegex);
+			if (matchFileType) {
+				if (matchFileType[1] === 'all') {
 					withFiles = true;
 					continue;
 				} else {
@@ -193,9 +194,9 @@ export default define(meta, async (ps, me) => {
 					return [];
 				}
 
-				const matchFile = matchExcludeWord[1].match(/^filetype:(\w+)$/);
-				if (matchFile) {
-					if (matchFile[1] === 'all') {
+				const matchFileType = matchExcludeWord[1].match(filetypeRegex);
+				if (matchFileType) {
+					if (matchFileType[1] === 'all') {
 						withFiles = false;
 						continue;
 					} else {


### PR DESCRIPTION
## Summary

検索にて from での絞り込みなどを可能にした。

---

スペース区切りで AND 検索にした
（OR 検索は正規表現で頑張ろうとすると大変そうだったので、とりあえず AND のみで……）

クオーテーションで囲むことで完全一致検索

- from
    - `from:@user`, `from:user`
    - NOT 検索可
- to
    - `to:@user`, `to:user`
    - 複数列挙で OR 検索
    - NOT 検索可
- filter
    - `filter:poll`, `filter:polls`
    - `filter:cw`
    - NOT 検索可
- filetype
    - `filetype:all`
        - 何かしらのファイルが添付されている
    - ファイルが添付されているノートがものすごく多いわけでもないので、画像のみで絞り込みなどは後で……
- since
    - `since:2020-01-01`
    - 指定した日付の0時からのノートで絞り込み
    - クライアントのタイムゾーンをどのように解釈させようか思いつかなかったので、とりあえず JST として扱う
- until
    - `until:2020-01-02`
    - 指定した日付の23時59分59秒までのノートで絞り込み

---

search.ts の L225 あたりとか if 文のゴリ押しがちょっと良くない気がするので、いい感じのやり方があったら……

あ、あと type, interface とかがいまいち理解できてない……