### PR TITLE
同一ノートにいくつもリアクションをつけれるように変更

### DIFF
--- a/migration/1598288528357-multiple-reactions.ts
+++ b/migration/1598288528357-multiple-reactions.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class multipleReactions1598288528357 implements MigrationInterface {
+    name = 'multipleReactions1598288528357'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "IDX_ad0c221b25672daf2df320a817"`);
+        await queryRunner.query(`CREATE INDEX "IDX_ad0c221b25672daf2df320a817" ON "note_reaction" ("userId", "noteId") `);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_a7751b74317122d11575bff31c" ON "note_reaction" ("userId", "noteId", "reaction") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "IDX_a7751b74317122d11575bff31c"`);
+        await queryRunner.query(`DROP INDEX "IDX_ad0c221b25672daf2df320a817"`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_ad0c221b25672daf2df320a817" ON "note_reaction" ("userId", "noteId") `);
+    }
+
+}

--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -71,11 +71,8 @@
 				<button v-else class="button _button">
 					<fa :icon="faBan"/>
 				</button>
-				<button v-if="appearNote.myReaction == null" class="button _button" @click="react()" ref="reactButton">
+				<button class="button _button" @click="react()" ref="reactButton">
 					<fa :icon="faPlus"/>
-				</button>
-				<button v-if="appearNote.myReaction != null" class="button _button reacted" @click="undoReact(appearNote)" ref="reactButton">
-					<fa :icon="faMinus"/>
 				</button>
 				<button class="button _button" @click="menu()" ref="menuButton">
 					<fa :icon="faEllipsisH"/>
@@ -366,7 +363,7 @@ export default Vue.extend({
 					};
 
 					if (body.userId === this.$store.state.i.id) {
-						n.myReaction = reaction;
+						n.myReactions.push(reaction);
 					}
 
 					this.updateAppearNote(n);
@@ -391,7 +388,7 @@ export default Vue.extend({
 					};
 
 					if (body.userId === this.$store.state.i.id) {
-						n.myReaction = null;
+						n.myReactions = n.myReactions.filter(r => r !== reaction);
 					}
 
 					this.updateAppearNote(n);
@@ -495,14 +492,6 @@ export default Vue.extend({
 			this.$root.api('notes/reactions/create', {
 				noteId: this.appearNote.id,
 				reaction: reaction
-			});
-		},
-
-		undoReact(note) {
-			const oldReaction = note.myReaction;
-			if (!oldReaction) return;
-			this.$root.api('notes/reactions/delete', {
-				noteId: note.id
 			});
 		},
 

--- a/src/client/components/reactions-viewer.reaction.vue
+++ b/src/client/components/reactions-viewer.reaction.vue
@@ -1,7 +1,7 @@
 <template>
 <button
 	class="hkzvhatu _button"
-	:class="{ reacted: note.myReaction == reaction, canToggle }"
+	:class="{ reacted: note.myReactions.includes(reaction), canToggle }"
 	@click="toggleReaction(reaction)"
 	v-if="count > 0"
 	@touchstart="onMouseover"
@@ -69,17 +69,10 @@ export default Vue.extend({
 		toggleReaction() {
 			if (!this.canToggle) return;
 
-			const oldReaction = this.note.myReaction;
-			if (oldReaction) {
+			if (this.note.myReactions.includes(this.reaction)) {
 				this.$root.api('notes/reactions/delete', {
-					noteId: this.note.id
-				}).then(() => {
-					if (oldReaction !== this.reaction) {
-						this.$root.api('notes/reactions/create', {
-							noteId: this.note.id,
-							reaction: this.reaction
-						});
-					}
+					noteId: this.note.id,
+					reaction: this.reaction
 				});
 			} else {
 				this.$root.api('notes/reactions/create', {

--- a/src/models/entities/note-reaction.ts
+++ b/src/models/entities/note-reaction.ts
@@ -4,7 +4,8 @@ import { Note } from './note';
 import { id } from '../id';
 
 @Entity()
-@Index(['userId', 'noteId'], { unique: true })
+@Index(['userId', 'noteId'], { unique: false })
+@Index(['userId', 'noteId', 'reaction'], { unique: true })
 export class NoteReaction {
 	@PrimaryColumn(id())
 	public id: string;

--- a/src/models/repositories/note.ts
+++ b/src/models/repositories/note.ts
@@ -188,17 +188,13 @@ export class NoteRepository extends Repository<Note> {
 			return all;
 		}
 
-		async function populateMyReaction() {
-			const reaction = await NoteReactions.findOne({
+		async function populateMyReactions() {
+			const reactions = await NoteReactions.find({
 				userId: meId!,
 				noteId: note.id,
 			});
 
-			if (reaction) {
-				return convertLegacyReaction(reaction.reaction);
-			}
-
-			return undefined;
+			return reactions.map(reaction => convertLegacyReaction(reaction.reaction));
 		}
 
 		let text = note.text;
@@ -245,7 +241,7 @@ export class NoteRepository extends Repository<Note> {
 				poll: note.hasPoll ? populatePoll() : undefined,
 
 				...(meId ? {
-					myReaction: populateMyReaction()
+					myReactions: populateMyReactions()
 				} : {})
 			} : {})
 		});
@@ -253,6 +249,10 @@ export class NoteRepository extends Repository<Note> {
 		if (packed.user.isCat && packed.text) {
 			const tokens = packed.text ? parse(packed.text) : [];
 			packed.text = toString(tokens, { doNyaize: true });
+		}
+
+		if (packed.myReactions) {
+			packed.myReaction = packed.myReactions[0];
 		}
 
 		if (!opts.skipHide) {

--- a/src/server/api/endpoints/notes/reactions/delete.ts
+++ b/src/server/api/endpoints/notes/reactions/delete.ts
@@ -32,6 +32,13 @@ export const meta = {
 				'en-US': 'Target note ID'
 			}
 		},
+
+		reaction: {
+			validator: $.optional.str,
+			desc: {
+				'ja-JP': 'リアクションの種類'
+			}
+		}
 	},
 
 	errors: {
@@ -54,7 +61,7 @@ export default define(meta, async (ps, user) => {
 		if (e.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 		throw e;
 	});
-	await deleteReaction(user, note).catch(e => {
+	await deleteReaction(user, note, ps.reaction || undefined).catch(e => {
 		if (e.id === '60527ec9-b4cb-4a88-a6bd-32d3ad26817d') throw new ApiError(meta.errors.notReacted);
 		throw e;
 	});


### PR DESCRIPTION
一人で複数回リアクションをつけれるように変更した

### 2個目以降について仕様

* スコア(ハイライトなどに利用される内部数値)は2個以上つけても変動しない (1人あたりリアクションでは1スコアまでしか影響しない)
* (現状使われていないので問題無いが) ActivityPub には初回リアクションのみを配信し、全てのリアクションが取り消された場合に unlike を配信するようになっている

### API の仕様変更

* Note のデータに `myReactions` が追加された
* `/api/notes/reactions/delete` のリクエストに `reaction` が追加され、指定した場合はそのリアクションが取り消されるようになった

##### 非互換な変更点

対応するのが面倒だったし、現状問題になるようなプログラムも確認されていないので無視する予定

* `/api/notes/reactions/create` ですでにリアクションがついていた場合に取り消されなくなった
  * create によって前のリアクションを取り消すことを想定して作られたクライアントで問題になるかも
* `/api/notes/reactions/delete` に `reaction` が指定されなかった場合でリアクションが複数ついている場合は、どれかが勝手に選ばれて取り消される
  * 全てのリアクションが消えることを期待したクライアントがあると問題になるかも

Resolves #29