### PR TITLE
リアクションをつけた順にソート

### DIFF
--- a/migration/1598579359831-reaction-timestamps.ts
+++ b/migration/1598579359831-reaction-timestamps.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class reactionTimestamps1598579359831 implements MigrationInterface {
+    name = 'reactionTimestamps1598579359831'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "note" ADD "reactionTimestamps" jsonb NOT NULL DEFAULT '{}'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "note" DROP COLUMN "reactionTimestamps"`);
+    }
+
+}

--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -361,6 +361,12 @@ export default Vue.extend({
 						...this.appearNote.reactions,
 						[reaction]: currentCount + 1
 					};
+					if (n.reactions[reaction] === 1) {
+						// 一度取り消されたリアクションだと appearNote.reactions[reaction] == 0 になっていて、
+						// 意図しない順番になってしまうので消して最後尾につけ治す
+						delete n.reactions[reaction];
+						n.reactions[reaction] = 1;
+					}
 
 					if (body.userId === this.$store.state.i.id) {
 						n.myReactions.push(reaction);

--- a/src/models/entities/note.ts
+++ b/src/models/entities/note.ts
@@ -98,6 +98,11 @@ export class Note {
 	})
 	public reactions: Record<string, number>;
 
+	@Column('jsonb', {
+		default: {}
+	})
+	public reactionTimestamps: Record<string, number>;
+
 	/**
 	 * public ... 公開
 	 * home ... ホームタイムライン(ユーザーページのタイムライン含む)のみに流す

--- a/src/models/repositories/note.ts
+++ b/src/models/repositories/note.ts
@@ -255,6 +255,18 @@ export class NoteRepository extends Repository<Note> {
 			packed.myReaction = packed.myReactions[0];
 		}
 
+		const reactionTimestamps = Object.keys(note.reactionTimestamps)
+			.reduce((o, k) => {
+				o[convertLegacyReaction(k)] = note.reactionTimestamps[k];
+				return o;
+			}, {});
+		packed.reactions = Object.keys(packed.reactions)
+			.sort((a, b) => (reactionTimestamps[a] || 0) - (reactionTimestamps[b] || 0))
+			.reduce((o, k) => {
+				o[k] = packed.reactions[k];
+				return o;
+			}, {});
+
 		if (!opts.skipHide) {
 			await this.hideNote(packed, meId);
 		}

--- a/src/services/note/reaction/create.ts
+++ b/src/services/note/reaction/create.ts
@@ -45,6 +45,14 @@ export default async (user: User, note: Note, reaction?: string) => {
 		.where('id = :id', { id: note.id })
 		.execute();
 
+	await Notes.createQueryBuilder().update()
+		.set({
+			reactionTimestamps: () => `jsonb_set("reactionTimestamps", '{${reaction}}', extract(epoch from now())::text::jsonb)`,
+		})
+		.where('id = :id', { id: note.id })
+		.andWhere(`"reactionTimestamps"->'${reaction}' IS NULL`)
+		.execute();
+
 
 	if (existReactions.length === 0) {
 		Notes.increment({ id: note.id }, 'score', 1);

--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -45,6 +45,14 @@ export default async (user: User, note: Note, reaction?: string) => {
 		.where('id = :id', { id: note.id })
 		.execute();
 
+	await Notes.createQueryBuilder().update()
+		.set({
+			reactionTimestamps: () => `"reactionTimestamps" - '${reaction}'`,
+		})
+		.where('id = :id', { id: note.id })
+		.andWhere(`"reactions"->>'${reaction}' = '0'`)
+		.execute();
+
 	if (other == null) {
 		Notes.decrement({ id: note.id }, 'score', 1);
 	}


### PR DESCRIPTION
リアクションが常に付けた順番にソートされるようにした

* note に jsonb 形式の `reactionTimestamps` カラムを追加した
  * 本家の更新とコンフリクトしなさそうな方法にしたらアドホックな感じになっちゃった
  * リアクション名と最初につけられた UNIX タイムスタンプのペアになってる
* API で返す前にその順番に reactions がソートされるようにしている
* `reactionTimestamps` に存在しない場合 (つまりこの変更が入る前につけられたリアクション) については順番が保証されない
  * 基本的には UNIX タイムスタンプが 0 扱いとなるため最初に来る
  * 変更が入ったあとに誰かがつけると、その時刻が記録されるため順番が変わる
    * このケースについてクライアントは正常に処理されないため、その時開いているクライアントでは変化せず、リロードすると順番が変わったようになる

Resolves #30 