### PR TITLE
固定ハッシュタグが文字数カウントに含まれない問題を修正

### DIFF
--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -183,7 +183,7 @@ export default Vue.extend({
 			return !this.posting &&
 				!this.uploading &&
 				(1 <= this.text.length || 1 <= this.files.length || this.poll || this.renote) &&
-				(length(this.buildText().trim()) <= this.max) &&
+				(length(this.buildText()) <= this.max) &&
 				(!this.poll || this.pollChoices.length >= 2);
 		},
 
@@ -555,9 +555,9 @@ export default Vue.extend({
 		},
 
 		buildText() {
-			let text = this.text;
+			let text = this.text.trim();
 			if (this.useHashtag) {
-				return text += "\n" + this.hashtag;
+				return text += "\n" + this.hashtag.trim();
 			} else {
 				return text;
 			}

--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -9,7 +9,7 @@
 		<button v-if="!fixed" class="cancel _button" @click="cancel"><fa :icon="faTimes"/></button>
 		<div>
 			<span class="local-only" v-if="localOnly" v-text="$t('_visibility.localOnly')" />
-			<span class="text-count" :class="{ over: trimmedLength(text) > max }">{{ max - trimmedLength(text) }}</span>
+			<span class="text-count" :class="{ over: trimmedLength(buildText()) > max }">{{ max - trimmedLength(buildText()) }}</span>
 			<button class="_button visibility" @click="setVisibility" ref="visibilityButton" v-tooltip="$t('visibility')">
 				<span v-if="visibility === 'public'"><fa :icon="faGlobe"/></span>
 				<span v-if="visibility === 'home'"><fa :icon="faHome"/></span>
@@ -557,17 +557,15 @@ export default Vue.extend({
 		buildText() {
 			let text = this.text;
 			if (this.useHashtag) {
-				text += "\n" + this.hashtag;
+				return text += "\n" + this.hashtag;
+			} else {
+				return text;
 			}
-			if (text === '') {
-				return undefined;
-			}
-			return text;
 		},
 
 		async post() {
 			let data = {
-				text: this.buildText(),
+				text: this.buildText() || undefined,
 				fileIds: this.files.length > 0 ? this.files.map(f => f.id) : undefined,
 				replyId: this.reply ? this.reply.id : undefined,
 				renoteId: this.renote ? this.renote.id : this.quoteId ? this.quoteId : undefined,

--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -183,7 +183,7 @@ export default Vue.extend({
 			return !this.posting &&
 				!this.uploading &&
 				(1 <= this.text.length || 1 <= this.files.length || this.poll || this.renote) &&
-				(length(this.text.trim()) <= this.max) &&
+				(length(this.buildText().trim()) <= this.max) &&
 				(!this.poll || this.pollChoices.length >= 2);
 		},
 


### PR DESCRIPTION
## Summary

固定ハッシュタグが有効なとき、投稿フォームの文字数カウントが正常でない問題を修正した。
また、文字数カウントがマイナスになっているとき（文字数制限以上）でも「ノート」ボタンがアクティブになってしまう問題を修正した。

Resolve #41
