### PR TITLE
デフォルトのタイムラインを social に変更

### DIFF
--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -26,7 +26,7 @@ export const defaultDeviceUserSettings = {
 	localOnly: false,
 	widgets: [],
 	tl: {
-		src: 'local'
+		src: 'social'
 	},
 	menu: [
 		'notifications',


### PR DESCRIPTION
#8 でデフォルトのタイムラインをローカルに変更したが、新機能のチャンネルなどのためにはソーシャルタイムラインのほうが便利なのでデフォルトを変更