### PR TITLE
カスタム絵文字を取り消したあとに順番が保持され続けるのを修正

### DIFF
--- a/src/services/note/reaction/delete.ts
+++ b/src/services/note/reaction/delete.ts
@@ -39,10 +39,10 @@ export default async (user: User, note: Note, reaction?: string) => {
 
 	await Notes.createQueryBuilder().update()
 		.set({
-			reactionTimestamps: () => `"reactionTimestamps" - '${reaction}'`,
+			reactionTimestamps: () => `"reactionTimestamps" - '${exist.reaction}'`,
 		})
 		.where('id = :id', { id: note.id })
-		.andWhere(`"reactions"->>'${reaction}' = '0'`)
+		.andWhere(`"reactions"->>'${exist.reaction}' = '0'`)
 		.execute();
 
 	if (existReactions.length === 1) {


### PR DESCRIPTION
## Summary

1. カスタム絵文字 A のリアクションをつける
2. それ以外の絵文字 B でリアクションをつける
3. カスタム絵文字 A のリアクションを取り消す
4. カスタム絵文字 A のリアクションを再度つける
5. ページをリロードする

で絵文字 B のあとにカスタム絵文字 A が来るのが期待されるが、結果は逆になるのを修正