### PR TITLE
絵文字補完最初にカスタム絵文字一覧を出すのを辞める

### DIFF
--- a/src/client/components/autocomplete.vue
+++ b/src/client/components/autocomplete.vue
@@ -274,11 +274,7 @@ export default Vue.extend({
 				}
 			} else if (this.type == 'emoji') {
 				if (this.q == null || this.q == '') {
-					this.emojis = this.emojiDb.filter(x => x.isCustomEmoji && !x.aliasOf).sort((a, b) => {
-						var textA = a.name.toUpperCase();
-						var textB = b.name.toUpperCase();
-						return (textA < textB) ? -1 : (textA > textB) ? 1 : 0;
-					});
+					this.emojis = [];
 					return;
 				}
 


### PR DESCRIPTION
## Summary

絵文字が多い環境では大量の要素を生成するため重たくなり固まってしまうので