### PR TITLE
サーバログの表示が途切れる問題を修正

### DIFF
--- a/src/client/pages/instance/index.vue
+++ b/src/client/pages/instance/index.vue
@@ -705,7 +705,6 @@ export default Vue.extend({
 			grid-template-columns: 2fr 3fr;
 			grid-template-rows: 1fr;
 			gap: 16px 16px;
-			height: 400px;
 		}
 	}
 


### PR DESCRIPTION
## Summary

モデレーションログとサーバログが横並びになっているとき、サーバログの表示が途切れる問題を修正した。

モデレーションログはデフォルトで10件取得なので、下部に変な余白ができるけどそこは無視してる。
