### PR TITLE
Webhook 通知

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -126,10 +126,12 @@ id: 'aid'
 # Job rate limiter
 # deliverJobPerSec: 128
 # inboxJobPerSec: 16
+# webhookJobPerSec: 1
 
 # Job attempts
 # deliverJobMaxAttempts: 12
 # inboxJobMaxAttempts: 8
+# webhookJobMaxAttempts: 5
 
 # IP address family used for outgoing request (ipv4, ipv6 or dual)
 #outgoingAddressFamily: ipv4

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -574,6 +574,7 @@ notificationSetting: "通知設定"
 notificationSettingDesc: "表示する通知の種別を選択してください。"
 useGlobalSetting: "グローバル設定を使う"
 useGlobalSettingDesc: "オンにすると、アカウントの通知設定が使用されます。オフにすると、個別に設定できるようになります。"
+webhookNotification: "Webhook 通知"
 
 _serverDisconnectedBehavior:
   reload: "自動でリロード"
@@ -1322,3 +1323,11 @@ _deck:
     list: "リスト"
     mentions: "あなた宛て"
     direct: "ダイレクト"
+
+_webhookNotification:
+  description: "Slack や Discord にて発行した Webhook URL に Slack 形式の JSON で POST します。インスタンス側の設定で許可されている場合のみ動作します。"
+  enable: "Webhook 通知を有効にする"
+  url: "POST 先 URL"
+  urlDescription: "Slack の場合は URL をそのまま入力します。Discord の場合は URL を入力し後、末尾に /slack を追加します。"
+  test: "送信テスト"
+  instanceDescription: "Webhook 通知を行うには有効にする必要があります。"

--- a/migration/1598986920665-WebhookNotification.ts
+++ b/migration/1598986920665-WebhookNotification.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class WebhookNotification1598986920665 implements MigrationInterface {
+    name = 'WebhookNotification1598986920665'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "user_profile" ADD "enableWebhookNotification" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ADD "webhookUrl" character varying(256)`);
+        await queryRunner.query(`CREATE INDEX "IDX_f0c7bece0ceafad7b18c34cbb8" ON "user_profile" ("enableWebhookNotification") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX "IDX_f0c7bece0ceafad7b18c34cbb8"`);
+        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "webhookUrl"`);
+        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "enableWebhookNotification"`);
+    }
+
+}

--- a/migration/1599309954647-webhook_instance_setting.ts
+++ b/migration/1599309954647-webhook_instance_setting.ts
@@ -1,0 +1,14 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class webhookInstanceSetting1599309954647 implements MigrationInterface {
+    name = 'webhookInstanceSetting1599309954647'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "meta" ADD "enableWebhookNotification" boolean NOT NULL DEFAULT false`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "enableWebhookNotification"`);
+    }
+
+}

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@sinonjs/fake-timers": "6.0.1",
 		"@syuilo/aiscript": "0.11.0",
 		"@types/bcryptjs": "2.4.2",
-		"@types/bull": "3.14.0",
+		"@types/bull": "3.14.2",
 		"@types/cbor": "5.0.1",
 		"@types/dateformat": "3.0.1",
 		"@types/double-ended-queue": "2.1.1",

--- a/src/client/pages/instance/index.vue
+++ b/src/client/pages/instance/index.vue
@@ -130,6 +130,9 @@
 			<x-queue :connection="queueConnection" domain="deliver" class="queue">
 				<template #title><fa :icon="faExchangeAlt"/> Out</template>
 			</x-queue>
+			<x-queue :connection="queueConnection" domain="webhook" class="queue">
+				<template #title><fa :icon="faExchangeAlt"/> Webhook</template>
+			</x-queue>
 		</div>
 	</mk-folder>
 
@@ -686,7 +689,7 @@ export default Vue.extend({
 
 		.vkyrmkwb {
 			display: grid;
-			grid-template-columns: 0.5fr 1fr 1fr;
+			grid-template-columns: 0.5fr 1fr 1fr 1fr;
 			grid-template-rows: 1fr;
 			gap: 16px 16px;
 			margin-bottom: var(--margin);

--- a/src/client/pages/instance/queue.chart.vue
+++ b/src/client/pages/instance/queue.chart.vue
@@ -187,7 +187,11 @@ export default Vue.extend({
 		},
 
 		fetchJobs() {
-			this.$root.api(this.domain === 'inbox' ? 'admin/queue/inbox-delayed' : this.domain === 'deliver' ? 'admin/queue/deliver-delayed' : null, {}).then(jobs => {
+			const path = this.domain === 'inbox' ? 'admin/queue/inbox-delayed' :
+						this.domain === 'deliver' ? 'admin/queue/deliver-delayed' :
+						this.domain === 'webhook' ? 'admin/queue/webhook-delayed' :
+						null
+			this.$root.api(path, {}).then(jobs => {
 				this.jobs = jobs;
 			});
 		},

--- a/src/client/pages/instance/queue.vue
+++ b/src/client/pages/instance/queue.vue
@@ -9,6 +9,9 @@
 	<x-queue :connection="connection" domain="deliver">
 		<template #title><fa :icon="faExchangeAlt"/> Out</template>
 	</x-queue>
+	<x-queue :connection="connection" domain="webhook">
+		<template #title><fa :icon="faExchangeAlt"/> Webhook</template>
+	</x-queue>
 	<section class="_card">
 		<div class="_content">
 			<mk-button @click="clear()"><fa :icon="faTrashAlt"/> {{ $t('clearQueue') }}</mk-button>

--- a/src/client/pages/instance/settings.vue
+++ b/src/client/pages/instance/settings.vue
@@ -117,6 +117,16 @@
 	</section>
 
 	<section class="_card _vMargin">
+		<div class="_title"><fa :icon="faLink"/> {{ $t('webhookNotification') }}</div>
+		<div class="_content">
+			<mk-switch v-model="enableWebhookNotification">{{ $t('_webhookNotification.enable') }}<template #desc>{{ $t('_webhookNotification.instanceDescription') }}</template></mk-switch>
+		</div>
+		<div class="_footer">
+			<mk-button primary @click="save(true)"><fa :icon="faSave"/> {{ $t('save') }}</mk-button>
+		</div>
+	</section>
+
+	<section class="_card _vMargin">
 		<div class="_title"><fa :icon="faThumbtack"/> {{ $t('pinnedUsers') }}</div>
 		<div class="_content">
 			<mk-textarea v-model="pinnedUsers">
@@ -296,6 +306,7 @@ export default Vue.extend({
 			enableServiceWorker: false,
 			swPublicKey: null,
 			swPrivateKey: null,
+			enableWebhookNotification: false,
 			useObjectStorage: false,
 			objectStorageBaseUrl: null,
 			objectStorageBucket: null,
@@ -364,6 +375,7 @@ export default Vue.extend({
 		this.enableServiceWorker = this.meta.enableServiceWorker;
 		this.swPublicKey = this.meta.swPublickey;
 		this.swPrivateKey = this.meta.swPrivateKey;
+		this.enableWebhookNotification = this.meta.enableWebhookNotification;
 		this.useObjectStorage = this.meta.useObjectStorage;
 		this.objectStorageBaseUrl = this.meta.objectStorageBaseUrl;
 		this.objectStorageBucket = this.meta.objectStorageBucket;
@@ -514,6 +526,7 @@ export default Vue.extend({
 				enableServiceWorker: this.enableServiceWorker,
 				swPublicKey: this.swPublicKey,
 				swPrivateKey: this.swPrivateKey,
+				enableWebhookNotification: this.enableWebhookNotification,
 				useObjectStorage: this.useObjectStorage,
 				objectStorageBaseUrl: this.objectStorageBaseUrl ? this.objectStorageBaseUrl : null,
 				objectStorageBucket: this.objectStorageBucket ? this.objectStorageBucket : null,

--- a/src/client/pages/my-settings/index.vue
+++ b/src/client/pages/my-settings/index.vue
@@ -31,6 +31,7 @@
 	<x-drive class="_vMargin"/>
 	<x-mute-block class="_vMargin"/>
 	<x-word-mute class="_vMargin"/>
+	<x-webhook class="_vMargin"/>
 	<x-security class="_vMargin"/>
 	<x-2fa class="_vMargin"/>
 	<x-integration class="_vMargin"/>
@@ -52,6 +53,7 @@ import XDrive from './drive.vue';
 import XReactionSetting from './reaction.vue';
 import XMuteBlock from './mute-block.vue';
 import XWordMute from './word-mute.vue';
+import XWebhook from './webhook.vue';
 import XSecurity from './security.vue';
 import X2fa from './2fa.vue';
 import XIntegration from './integration.vue';
@@ -74,6 +76,7 @@ export default Vue.extend({
 		XReactionSetting,
 		XMuteBlock,
 		XWordMute,
+		XWebhook,
 		XSecurity,
 		X2fa,
 		XIntegration,

--- a/src/client/pages/my-settings/webhook.vue
+++ b/src/client/pages/my-settings/webhook.vue
@@ -12,6 +12,7 @@
 		</mk-input>
 	</div>
 	<div class="_footer">
+		<mk-button @click="test()" inline :disabled="!url">{{ $t('_webhookNotification.test') }}</mk-button>
 		<mk-button @click="save(true)" primary inline :disabled="!changed"><fa :icon="faSave"/> {{ $t('save') }}</mk-button>
 	</div>
 </section>
@@ -67,6 +68,19 @@ export default Vue.extend({
 				this.$root.dialog({
 					type: 'error',
 					text: err.id,
+				});
+			});
+		},
+
+		test() {
+			this.save(false);
+			// ここではジョブキューに追加するだけにして、送信エラーは"通知"でユーザーに知らせる
+			this.$root.api('notifications/webhook-test').then(() => {
+				console.log('postJobQueue Add');
+			}).catch((err) => {
+				this.$root.dialog({
+					type: 'error',
+					text: err,
 				});
 			});
 		},

--- a/src/client/pages/my-settings/webhook.vue
+++ b/src/client/pages/my-settings/webhook.vue
@@ -1,0 +1,75 @@
+<template>
+<section class="_card">
+	<div class="_title"><fa :icon="faLink"/> {{ $t('webhookNotification') }}</div>
+		<div class="_content">
+		<mk-info>{{ $t('_webhookNotification.description')}}</mk-info>
+		<mk-switch v-model="enableWebhook" @change="save()">
+			{{ $t('_webhookNotification.enable') }}
+		</mk-switch>
+		<mk-input v-model="url">
+			<span>{{ $t('_webhookNotification.url') }}</span>
+			<template #desc>{{ $t('_webhookNotification.urlDescription') }}</template>
+		</mk-input>
+	</div>
+	<div class="_footer">
+		<mk-button @click="save(true)" primary inline :disabled="!changed"><fa :icon="faSave"/> {{ $t('save') }}</mk-button>
+	</div>
+</section>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { faLink } from '@fortawesome/free-solid-svg-icons';
+import { faSave } from '@fortawesome/free-regular-svg-icons';
+import MkButton from '../../components/ui/button.vue';
+import MkInput from '../../components/ui/input.vue';
+import MkSwitch from '../../components/ui/switch.vue';
+import MkInfo from '../../components/ui/info.vue';
+
+export default Vue.extend({
+	components: {
+		MkButton,
+		MkInput,
+		MkSwitch,
+		MkInfo,
+	},
+	
+	data() {
+		return {
+			enableWebhook: this.$store.state.i.enableWebhookNotification,
+			url: this.$store.state.i.webhookUrl,
+			changed: false,
+			faSave, faLink,
+		}
+	},
+
+	watch: {
+		url() {
+			this.changed = true;
+		},
+	},
+
+	methods: {
+		save(notify?: boolean) {
+			this.$root.api('i/update', {
+				enableWebhookNotification: this.enableWebhook,
+				webhookUrl: this.url || null,
+			}).then(() => {
+				this.changed = false;
+				if (notify) {
+					this.$root.dialog({
+						type: 'success',
+						iconOnly: true,
+						autoClose: true,
+					});
+				}
+			}).catch((err) => {
+				this.$root.dialog({
+					type: 'error',
+					text: err.id,
+				});
+			});
+		},
+	},
+});
+</script>

--- a/src/client/pages/my-settings/webhook.vue
+++ b/src/client/pages/my-settings/webhook.vue
@@ -54,8 +54,8 @@ export default Vue.extend({
 	},
 
 	methods: {
-		save(notify?: boolean) {
-			this.$root.api('i/update', {
+		async save(notify?: boolean) {
+			await this.$root.api('i/update', {
 				enableWebhookNotification: this.enableWebhook,
 				webhookUrl: this.url || null,
 			}).then(() => {
@@ -75,8 +75,8 @@ export default Vue.extend({
 			});
 		},
 
-		test() {
-			this.save(false);
+		async test() {
+			await this.save(false);
 			// ここではジョブキューに追加するだけにして、送信エラーは"通知"でユーザーに知らせる
 			this.$root.api('notifications/webhook-test').then(() => {
 				console.log('postJobQueue Add');

--- a/src/client/pages/my-settings/webhook.vue
+++ b/src/client/pages/my-settings/webhook.vue
@@ -3,7 +3,7 @@
 	<div class="_title"><fa :icon="faLink"/> {{ $t('webhookNotification') }}</div>
 		<div class="_content">
 		<mk-info>{{ $t('_webhookNotification.description')}}</mk-info>
-		<mk-switch v-model="enableWebhook" @change="save()">
+		<mk-switch v-model="enableWebhook">
 			{{ $t('_webhookNotification.enable') }}
 		</mk-switch>
 		<mk-input v-model="url">
@@ -46,6 +46,9 @@ export default Vue.extend({
 
 	watch: {
 		url() {
+			this.changed = true;
+		},
+		enableWebhook() {
 			this.changed = true;
 		},
 	},

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -49,8 +49,10 @@ export type Source = {
 	inboxJobConcurrency?: number;
 	deliverJobPerSec?: number;
 	inboxJobPerSec?: number;
+	webhookJobPerSec?: number;
 	deliverJobMaxAttempts?: number;
 	inboxJobMaxAttempts?: number;
+	webhookJobMaxAttempts?: number;
 
 	syslog: {
 		host: string;

--- a/src/models/entities/meta.ts
+++ b/src/models/entities/meta.ts
@@ -241,6 +241,11 @@ export class Meta {
 	@Column('boolean', {
 		default: false,
 	})
+	public enableWebhookNotification: boolean;
+
+	@Column('boolean', {
+		default: false,
+	})
 	public enableTwitterIntegration: boolean;
 
 	@Column('varchar', {

--- a/src/models/entities/user-profile.ts
+++ b/src/models/entities/user-profile.ts
@@ -166,6 +166,17 @@ export class UserProfile {
 	})
 	public includingNotificationTypes: typeof notificationTypes[number][] | null;
 
+	@Index()
+	@Column('boolean', {
+		default: false
+	})
+	public enableWebhookNotification: boolean;
+
+	@Column('varchar', {
+		length: 256, nullable: true,
+	})
+	public webhookUrl: string | null;
+
 	//#region Denormalized fields
 	@Index()
 	@Column('varchar', {

--- a/src/models/repositories/user.ts
+++ b/src/models/repositories/user.ts
@@ -249,6 +249,8 @@ export class UserRepository extends Repository<User> {
 				integrations: profile!.integrations,
 				mutedWords: profile!.mutedWords,
 				includingNotificationTypes: profile?.includingNotificationTypes,
+				enableWebhookNotification: profile!.enableWebhookNotification,
+				webhookUrl: profile?.webhookUrl,
 			} : {}),
 
 			...(opts.includeSecrets ? {

--- a/src/queue/processors/webhook.ts
+++ b/src/queue/processors/webhook.ts
@@ -1,0 +1,114 @@
+import * as Bull from 'bull';
+import { getAgentByUrl } from '../../misc/fetch';
+import getNoteSummary from '../../misc/get-note-summary';
+import fetch from 'node-fetch';
+import * as locale from '../../../locales/';
+import config from '../../config';
+import { notificationType, notificationBody } from '../../services/push-notification';
+import { PostWebhookJobData } from '..';
+
+export default async (job: Bull.Job<PostWebhookJobData>) => {
+	await fetch(job.data.url, {
+		method: 'POST',
+		headers: {
+			'Content-type': 'application/json',
+		},
+		agent: getAgentByUrl(job.data.url) as any,
+		// TODO: Webhook 通知で使われる言語を設定画面で変更できるように
+		body: buildWebhookBody(job.data.type, job.data.body, locale['ja-JP']),
+	})
+	.catch(() => {
+		throw 'network error (server side) or illegal URL';
+	})
+	.then((res) => {
+		if (res.ok) {
+			return 'Success';
+		} else {
+			const errorText = `${res.status} - ${res.statusText} - userId: ${job.data.userId}`;
+			// Rate Limit を超えている or POST 先サーバのエラー のためリトライ
+			if (res.status === 429 || (500 <= res.status && res.status < 600)) {
+				throw errorText;
+			}
+			// ユーザーによる Webhook URL の設定ミスなどのためスキップ
+			return `skip (URL setting miss?) ${errorText}`;
+		}
+	});
+};
+
+
+const buildWebhookBody = (type: notificationType, body: any, locale: any) => {
+	let typeText = '';
+	let quoteText = '';
+	// 通知送信者のユーザー名 (ex. user)
+	const name = body.user.name || body.user.username;
+	// 通知送信者のユーザー名 (ex. @localuser, @remoteuser@example.com)
+	const username = body.user.host ? `@${body.user.username}@${body.user.host}` : `@${body.user.username}`;
+
+	const noteDetail = body.note ? `${getNoteSummary(body.note, locale)}\n${config.url}/notes/${body.note.id}` : '';
+	const notifier = `${name} (${username})`;
+
+	switch (type) {
+		case 'notification':
+			switch (body.type) {
+				case 'mention':
+					typeText = locale['_notification']['youGotMention'].replace('{name}', body.user.username);
+					quoteText = noteDetail;
+					break;
+				case 'reply':
+					typeText = locale['_notification']['youGotReply'].replace('{name}', body.user.username);
+					quoteText = noteDetail;
+					break;
+				case 'renote':
+					typeText = locale['_notification']['youRenoted'].replace('{name}', body.user.username);
+					quoteText = noteDetail;
+					break;
+				case 'quote':
+					typeText = locale['_notification']['youGotQuote'].replace('{name}', body.user.username);
+					quoteText = noteDetail;
+					break;
+				case 'reaction':
+					typeText = `${body.reaction} by ${body.user.username}`;
+					quoteText = noteDetail;
+					break;
+				case 'follow':
+					typeText = `${locale['_notification']['youWereFollowed']} (${body.user.username})`;
+					quoteText = notifier;
+					break;
+				case 'receiveFollowRequest':
+					typeText = `${locale['_notification']['youReceivedFollowRequest']} (${body.user.username})`;
+					quoteText = notifier;
+					break;
+				case 'followRequestAccepted':
+					typeText = `${locale['_notification']['yourFollowRequestAccepted']} (${body.user.username})`;
+					quoteText = notifier;
+					break;
+				case 'groupInvited':
+					typeText = `${locale['_notification']['youWereInvitedToGroup']} (${body.invitation.group.name})`;
+					quoteText = notifier;
+					break;
+				default:
+					typeText = 'Notification (unknown)';
+					break;
+			}
+			break;
+		case 'unreadMessagingMessage':
+			if (body.groupId === null) {
+				typeText = locale['_notification']['youGotMessagingMessageFromUser'].replace('{name}', body.user.username);
+			} else {
+				typeText = locale['_notification']['youGotMessagingMessageFromGroup'].replace('{name}', body.group.name);
+			}
+			quoteText = body.text;
+			break;
+	}
+
+	const attachment = {
+		fallback: 'Notification detail',
+		color: 'good',
+		text: quoteText,
+	};
+
+	return JSON.stringify({
+		text: typeText,
+		attachments: [attachment],
+	});
+};

--- a/src/server/api/endpoints/admin/queue/stats.ts
+++ b/src/server/api/endpoints/admin/queue/stats.ts
@@ -1,5 +1,5 @@
 import define from '../../../define';
-import { deliverQueue, inboxQueue, dbQueue, objectStorageQueue } from '../../../../../queue';
+import { deliverQueue, inboxQueue, dbQueue, objectStorageQueue, webhookQueue } from '../../../../../queue';
 
 export const meta = {
 	tags: ['admin'],
@@ -15,11 +15,13 @@ export default define(meta, async (ps) => {
 	const inboxJobCounts = await inboxQueue.getJobCounts();
 	const dbJobCounts = await dbQueue.getJobCounts();
 	const objectStorageJobCounts = await objectStorageQueue.getJobCounts();
+	const webhookJobCounts = await webhookQueue.getJobCounts();
 
 	return {
 		deliver: deliverJobCounts,
 		inbox: inboxJobCounts,
 		db: dbJobCounts,
 		objectStorage: objectStorageJobCounts,
+		webhook: webhookJobCounts,
 	};
 });

--- a/src/server/api/endpoints/admin/queue/webhook-delayed.ts
+++ b/src/server/api/endpoints/admin/queue/webhook-delayed.ts
@@ -1,0 +1,30 @@
+import define from '../../../define';
+import { webhookQueue } from '../../../../../queue';
+
+export const meta = {
+	tags: ['admin'],
+
+	requireCredential: true as const,
+	requireModerator: true,
+
+	params: {
+	}
+};
+
+export default define(meta, async (ps) => {
+	const jobs = await webhookQueue.getJobs(['delayed']);
+
+	const res = [] as [string, number][];
+
+	for (const job of jobs) {
+		if (res.find(x => x[0] === job.data.userId)) {
+			res.find(x => x[0] === job.data.userId)![1]++;
+		} else {
+			res.push([job.data.userId, 1]);
+		}
+	}
+
+	res.sort((a, b) => b[1] - a[1]);
+
+	return res;
+});

--- a/src/server/api/endpoints/admin/update-meta.ts
+++ b/src/server/api/endpoints/admin/update-meta.ts
@@ -355,6 +355,13 @@ export const meta = {
 			}
 		},
 
+		enableWebhookNotification: {
+			validator: $.optional.bool,
+			desc: {
+				'ja-JP': 'Webhook 通知を有効にするか否か'
+			}
+		},
+
 		tosUrl: {
 			validator: $.optional.nullable.str,
 			desc: {
@@ -619,6 +626,10 @@ export default define(meta, async (ps, me) => {
 
 	if (ps.swPrivateKey !== undefined) {
 		set.swPrivateKey = ps.swPrivateKey;
+	}
+
+	if (ps.enableWebhookNotification !== undefined) {
+		set.enableWebhookNotification = ps.enableWebhookNotification;
 	}
 
 	if (ps.tosUrl !== undefined) {

--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -152,6 +152,21 @@ export const meta = {
 		includingNotificationTypes: {
 			validator: $.optional.arr($.str.or(notificationTypes as unknown as string[]))
 		},
+
+		enableWebhookNotification: {
+			validator: $.optional.bool,
+			desc: {
+				'ja-JP': 'Webhook 通知を有効にするか否か'
+			}
+		},
+
+		webhookUrl: {
+			// TODO: URL validation
+			validator: $.optional.nullable.str.max(256),
+			desc: {
+				'ja-JP': 'Webhook 通知の POST 先 URL'
+			}
+		},
 	},
 
 	errors: {
@@ -215,6 +230,8 @@ export default define(meta, async (ps, user, token) => {
 	if (typeof ps.autoWatch === 'boolean') profileUpdates.autoWatch = ps.autoWatch;
 	if (typeof ps.injectFeaturedNote === 'boolean') profileUpdates.injectFeaturedNote = ps.injectFeaturedNote;
 	if (typeof ps.alwaysMarkNsfw === 'boolean') profileUpdates.alwaysMarkNsfw = ps.alwaysMarkNsfw;
+	if (typeof ps.enableWebhookNotification === 'boolean') profileUpdates.enableWebhookNotification = ps.enableWebhookNotification;
+	if (ps.webhookUrl !== undefined) profileUpdates.webhookUrl = ps.webhookUrl;
 
 	if (ps.avatarId) {
 		const avatar = await DriveFiles.findOne(ps.avatarId);

--- a/src/server/api/endpoints/meta.ts
+++ b/src/server/api/endpoints/meta.ts
@@ -143,6 +143,7 @@ export default define(meta, async (ps, me) => {
 		enableDiscordIntegration: instance.enableDiscordIntegration,
 
 		enableServiceWorker: instance.enableServiceWorker,
+		enableWebhookNotification: instance.enableWebhookNotification,
 	};
 
 	if (ps.detail) {

--- a/src/server/api/endpoints/notifications/webhook-test.ts
+++ b/src/server/api/endpoints/notifications/webhook-test.ts
@@ -1,0 +1,62 @@
+import define from '../../define';
+import { Notifications, UserProfiles } from '../../../../models';
+import { ensure } from '../../../../prelude/ensure';
+import { postWebhookJob } from '../../../../queue';
+import { fetchMeta } from '../../../../misc/fetch-meta';
+import { ApiError } from '../../../api/error';
+
+export const meta = {
+	desc: {
+		'ja-JP': 'Webhook 通知のテストします。',
+	},
+
+	tags: ['notifications'],
+
+	requireCredential: true as const,
+
+	kind: 'read:notifications',
+
+	errors: {
+		instanceDisableWebhookNotification: {
+			message: 'This instance disable Webhook notification.',
+			code: 'INSTANCE_DISABLE_WEBHOOK_NOTIFICATION',
+			id: '2e0cca8e-f95b-435b-b082-1826543cd3ea',
+			kind: 'server' as const,
+		},
+
+		emptyWebhookUrl: {
+			message: 'Webhook URL is empty.',
+			code: 'EMPTY_WEBHOOK_URL',
+			id: '3a1de390-e88c-469b-98d4-037457ee5d89',
+		},
+
+		emptyNotification: {
+			message: 'Your notification is empty.',
+			code: 'EMPTY_YOUR_NOTIFICATION',
+			id: '8f553673-91e4-41fc-9414-f171af48c295',
+		},
+	},
+};
+
+export default define(meta, async (ps, user) => {
+	const instance = await fetchMeta();
+	if (!instance.enableWebhookNotification) throw new ApiError(meta.errors.instanceDisableWebhookNotification);
+	const profile = await UserProfiles.findOne({userId: user.id}).then(ensure);
+	if (profile.webhookUrl == null) throw new ApiError(meta.errors.emptyWebhookUrl);
+
+	// テスト用の通知を作成するのは面倒なので直近1件の通知を送信する
+	const mostResent = await Notifications.findOne({
+		where: {
+			notifieeId: user.id,
+		},
+		order: {
+			createdAt: 'DESC',
+		},
+	}).then(ensure)
+	.catch(() => {
+		throw new ApiError(meta.errors.emptyNotification);
+	});
+
+	const packed = await Notifications.pack(mostResent);
+	postWebhookJob(user.id, 'notification', packed, profile.webhookUrl);
+});

--- a/src/server/api/endpoints/notifications/webhook-test.ts
+++ b/src/server/api/endpoints/notifications/webhook-test.ts
@@ -4,6 +4,7 @@ import { ensure } from '../../../../prelude/ensure';
 import { postWebhookJob } from '../../../../queue';
 import { fetchMeta } from '../../../../misc/fetch-meta';
 import { ApiError } from '../../../api/error';
+import { Not } from 'typeorm';
 
 export const meta = {
 	desc: {
@@ -48,6 +49,7 @@ export default define(meta, async (ps, user) => {
 	const mostResent = await Notifications.findOne({
 		where: {
 			notifieeId: user.id,
+			type: Not('app'),
 		},
 		order: {
 			createdAt: 'DESC',

--- a/src/services/create-notification.ts
+++ b/src/services/create-notification.ts
@@ -1,5 +1,5 @@
 import { publishMainStream } from './stream';
-import pushSw from './push-notification';
+import pushNotification from './push-notification';
 import { Notifications, Mutings, UserProfiles } from '../models';
 import { genId } from '../misc/gen-id';
 import { User } from '../models/entities/user';
@@ -50,7 +50,7 @@ export async function createNotification(
 
 			publishMainStream(notifieeId, 'unreadNotification', packed);
 
-			pushSw(notifieeId, 'notification', packed);
+			pushNotification(notifieeId, 'notification', packed);
 		}
 	}, 2000);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -238,10 +238,10 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/bull@3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@types/bull/-/bull-3.14.0.tgz#60741d3f5006bd4e17b02ff036e6ecef7ac47a6e"
-  integrity sha512-9MKWQ4Q+GFIEA3/SdSc128mAccCKni2YVMKPEdQY5qooN+3gl0Po+f7kaKukgn5s6YXj5xbvc/zTaMsHZL9GvA==
+"@types/bull@3.14.2":
+  version "3.14.2"
+  resolved "https://registry.yarnpkg.com/@types/bull/-/bull-3.14.2.tgz#18c1d9a9dd079ca63971b4d0fac16fc9f5777491"
+  integrity sha512-+g3Qha7ObdadnM4v/Sz9WDx8eKEaRL4usQmkeUEC25uAltFLioDbAaLnUggfWHONVzW2AxOgzS19ekMmx6zLzA==
   dependencies:
     "@types/ioredis" "*"
 


### PR DESCRIPTION
## Summary

Service Worker を利用した通知の代替として、Slack や Discord 宛に POST する機能を追加した。


## 想定している挙動など

- ユーザーごとやインスタンス全体で有効無効を切り替え可能
- 送信する JSON の形式は Slack の attachment を利用したもの
- インスタンスで無効になっていても、各ユーザーの設定は有効にできる（実際には POST されない）
    - 表示的にはまぎらわしいので、時間があったら考える
- 送信テスト
    - 成功時は何もなし
    - 失敗時は"通知"にアプリ通知として表示される
- POST される通知の種類はアカウント設定→通知設定に依存する
- en-US の翻訳は面倒になってやってない
- 「userがRenoteしました」などの POST されるメッセージは ja-JP のみ
    - 現時点では変更可能にする必要性をあまり感じなかった
- Webhook URL のバリデーションはない
    - あまりにも奥が深そうでやめた
    - 現時点では Slack or Discord なのでドメインでバリデーションでもあったほうがよい？

