### PR TITLE
固定ハッシュタグのinputで投稿ショートカットが動作するように

### DIFF
--- a/src/client/components/post-form.vue
+++ b/src/client/components/post-form.vue
@@ -35,7 +35,7 @@
 		</div>
 		<input v-show="useCw" ref="cw" class="cw" v-model="cw" :placeholder="$t('annotation')" v-autocomplete="{ model: 'cw' }">
 		<textarea v-model="text" class="text" :class="{ withCw: useCw, withHashtag: useHashtag }" ref="text" :disabled="posting" :placeholder="placeholder" v-autocomplete="{ model: 'text' }" @keydown="onKeydown" @paste="onPaste"></textarea>
-		<input v-show="useHashtag" ref="hashtag" class="hashtag" v-model="hashtag" :placeholder="$t('hashtagPlaceholder')" v-autocomplete="{ model: 'hashtag' }">
+		<input v-show="useHashtag" ref="hashtag" class="hashtag" v-model="hashtag" :placeholder="$t('hashtagPlaceholder')" v-autocomplete="{ model: 'hashtag' }" @keydown="onKeydown">
 		<x-post-form-attaches class="attaches" :files="files"/>
 		<x-poll-editor v-if="poll" ref="poll" @destroyed="poll = false" @updated="onPollUpdate()"/>
 		<x-uploader ref="uploader" @uploaded="attachMedia" @change="onChangeUploadings"/>


### PR DESCRIPTION
## Summary

固定ハッシュタグのinputにフォーカスしている状態でも、投稿ショートカットが動作するようにした。