### PR TITLE
Channel 投稿を削除して編集すると、一般 TL に投稿してしまう問題を修正

### DIFF
--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -546,7 +546,7 @@ export default Vue.extend({
 					noteId: this.appearNote.id
 				});
 
-				this.$root.post({ initialNote: this.appearNote, renote: this.appearNote.renote, reply: this.appearNote.reply });
+				this.$root.post({ initialNote: this.appearNote, renote: this.appearNote.renote, reply: this.appearNote.reply, channel: this.appearNote.channel });
 			});
 		},
 

--- a/src/client/components/post-form-dialog.vue
+++ b/src/client/components/post-form-dialog.vue
@@ -16,6 +16,7 @@
 				:initial-text="initialText"
 				:initial-note="initialNote"
 				:instant="instant"
+				:channel="channel"
 				@posted="onPosted"
 				@cancel="onCanceled"
 				style="border-radius: var(--radius);"/>
@@ -62,7 +63,11 @@ export default Vue.extend({
 			type: Boolean,
 			required: false,
 			default: false
-		}
+		},
+		channel: {
+			type: Object,
+			required: false
+		},
 	},
 
 	data() {


### PR DESCRIPTION
## Summary

Channel 投稿を削除して編集後にノートすると、チャンネルではなく一般 TL に流れてしまう問題を修正した。