### PR TITLE
チャンネル一覧でバナー画像が無い場合でも同じ表示になるように

### DIFF
--- a/src/client/components/channel-preview.vue
+++ b/src/client/components/channel-preview.vue
@@ -1,6 +1,6 @@
 <template>
 <router-link :to="`/channels/${channel.id}`" class="eftoefju _panel" tabindex="-1">
-	<div class="banner" v-if="channel.bannerUrl" :style="`background-image: url('${channel.bannerUrl}')`">
+	<div class="banner" :style="bannerStyle">
 		<div class="fade"></div>
 		<div class="name"><fa :icon="faSatelliteDish"/> {{ channel.name }}</div>
 		<div class="status">
@@ -29,6 +29,16 @@ export default Vue.extend({
 			type: Object,
 			required: true
 		},
+	},
+
+	computed: {
+		bannerStyle() {
+			if (this.channel.bannerUrl) {
+				return { backgroundImage: `url(${this.channel.bannerUrl})` };
+			} else {
+				return { backgroundColor: '#4c5e6d' };
+			}
+		}
 	},
 
 	data() {


### PR DESCRIPTION
## Summary

今までバナーが無いと以下のように、 description しか表示されるチャンネル名などの情報が見れない状態でした

<img width="666" alt="Screen Shot 2020-09-21 at 22 42 49" src="https://user-images.githubusercontent.com/22152877/93775698-b3632a00-fc5d-11ea-8c5e-1621cf0db6f3.png">

これをバナーが無い場合は背景色だけつけて、チャンネル名などの情報が表示されるようにしました

<img width="665" alt="Screen Shot 2020-09-21 at 22 52 28" src="https://user-images.githubusercontent.com/22152877/93775804-d2fa5280-fc5d-11ea-969b-8b4b5afd8bc3.png">
