### PR TITLE
ノートの勢い表示を追加

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -571,6 +571,7 @@ delayed: "Delayed"
 database: "Database"
 channel: "Channel"
 create: "Create"
+momentum: "Momentum"
 _serverDisconnectedBehavior:
   reload: "Automatically reload"
   dialog: "Show warning dialog"

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -576,6 +576,7 @@ useGlobalSetting: "グローバル設定を使う"
 useGlobalSettingDesc: "オンにすると、アカウントの通知設定が使用されます。オフにすると、個別に設定できるようになります。"
 autoShowCwContent: "CW 投稿の自動展開"
 webhookNotification: "Webhook 通知"
+momentum: "勢い"
 
 _serverDisconnectedBehavior:
   reload: "自動でリロード"

--- a/src/client/components/instance-stats.vue
+++ b/src/client/components/instance-stats.vue
@@ -59,6 +59,10 @@
 					<dt>{{ $t('weekOverWeekChanges') }}</dt>
 					<dd>{{ notesLocalWoW | number }}</dd>
 				</dl>
+				<dl>
+					<dt>{{ $t('momentum') }}</dt>
+					<dd>{{ info.originalNotesMomentumCount | number }}</dd>
+				</dl>
 			</div>
 		</div>
 		<div class="_panel">


### PR DESCRIPTION
## Summary

/about に、ローカルにおける直近1分のノート数（勢い）の表示を追加した。

![ss_2020-09-30_15-54-54](https://user-images.githubusercontent.com/37328795/94652642-563e3700-0335-11eb-91c6-67a6b490fca2.png)

Resolve #31

