### PR TITLE
トレンドで同一スコアなら新しいノートを優先する

### DIFF
--- a/src/server/api/endpoints/notes/featured.ts
+++ b/src/server/api/endpoints/notes/featured.ts
@@ -55,6 +55,7 @@ export default define(meta, async (ps, user) => {
 
 	let notes = await query
 		.orderBy('note.score', 'DESC')
+		.addOrderBy('note.createdAt', 'DESC')
 		.take(max)
 		.getMany();
 


### PR DESCRIPTION
## Summary

トレンド機能は「過去3日間でスコアが高い上位30ノートを表示」しますが、30個目と31個目などが同じスコアだった場合にどちらが採用されるかが保証されていない状態でした。これを同一スコアであれば新しいノートを優先することによって、スコア的にはトレンド入りするノートでも3日前のノートなどがトレンドに残って新しいノートが増えにくい状況を防止します。