### PR TITLE
注釈が空のCW投稿が自動展開されないバグを修正

### DIFF
--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -279,7 +279,7 @@ export default Vue.extend({
 			}
 		}
 
-		if (this.appearNote.cw || this.appearNote.cw === '') {
+		if (this.appearNote.cw != null) {
 			this.showContent = this.$store.state.device.autoShowCwContentAll ||
 				(this.$store.state.device.showCwWords as string[])
 					.some(word => this.appearNote.cw.includes(word) || this.appearNote.text.includes(word));

--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -279,7 +279,7 @@ export default Vue.extend({
 			}
 		}
 
-		if (this.appearNote.cw) {
+		if (this.appearNote.cw || this.appearNote.cw === '') {
 			this.showContent = this.$store.state.device.autoShowCwContentAll ||
 				(this.$store.state.device.showCwWords as string[])
 					.some(word => this.appearNote.cw.includes(word) || this.appearNote.text.includes(word));


### PR DESCRIPTION
## Summary

#68 で実装された機能によって発生する、「すべての CW 投稿を自動展開する」が有効のとき、CW欄が空の投稿が自動で展開されないバグを修正した。

CW投稿でない場合は`cw`が`null`に、CW投稿であるが注釈に何も入力していない場合は`cw`が`''`になる。

