### PR TITLE
一部ページをウィンドウ化できないのを修正

### DIFF
--- a/src/client/router.ts
+++ b/src/client/router.ts
@@ -107,7 +107,6 @@ export function resolve(path: string) {
 	const route = resolved.matched[0];
 	return {
 		component: markRaw(route.components.default),
-		// TODO: route.propsには関数以外も入る可能性があるのでよしなにハンドリングする
-		props: route.props?.default ? route.props.default(resolved) : resolved.params
+		props: typeof route.props?.default === 'function' ? route.props.default(resolved) : resolved.params
 	};
 }


### PR DESCRIPTION
## Summary

チャンネルのページなど、一部右クリックからウィンドウやサイドバーで表示できないのを修正します。
具体的には router.ts ファイル内の `props: true` になっているページで `route.props.default` が function が無い場合にエラーになっているのが問題なので、 `typeof` を使ってチェックするようにしました。