### PR TITLE
/api/i/update が Invalid param. になるのを修正

### DIFF
--- a/src/server/api/endpoints/i/update.ts
+++ b/src/server/api/endpoints/i/update.ts
@@ -169,7 +169,7 @@ export const meta = {
 		},
 
 		webhookType: {
-			validator: $.str.or(webhookTypes as unknown as string[]),
+			validator: $.optional.str.or(webhookTypes as unknown as string[]),
 			desc: {
 				'ja-JP': 'Webhook 通知によって POST する JSON の形式',
 			},


### PR DESCRIPTION
## Summary

プロフィール編集で保存を押した時などに `/api/i/update` で以下のエラーが帰ってきて編集できないので修正します。

```json
{"error":{"message":"Invalid param.","code":"INVALID_PARAM","id":"3d81ceae-475f-4600-b2a8-2bc116157532","kind":"client","info":{"param":"webhookType","reason":"must-be-not-undefined"}}}
```