### PR TITLE
初期表示時にチャンネルカラムのフォームにフォーカスされる問題を修正

### DIFF
--- a/src/client/ui/deck/ch-column.vue
+++ b/src/client/ui/deck/ch-column.vue
@@ -5,7 +5,7 @@
 		<span style="margin-left: 8px;">{{ column.name }}</span>
 	</template>
 
-	<XPostForm v-if="showFixedPostForm" :channel="{ id: column.chId }" class="" fixed/>
+	<XPostForm v-if="showFixedPostForm" :channel="{ id: column.chId }" class="" fixed :autofocus="false"/>
 	<XTimeline v-if="column.chId" ref="timeline" src="channel" :channel="column.chId" @after="() => $emit('loaded')" @queue="queueUpdated" @note="onNote" :key="column.chId"/>
 </XColumn>
 </template>


### PR DESCRIPTION
## Summary

初期表示時に、メインTLのフォームではなくチャンネルカラムのそれにフォーカスされる問題を修正しました。

デフォルトだとオートフォーカスが有効なので、無効にするようにしました。
ウィジェットである [src/client/widgets/post-form.vue](https://github.com/coins20/misskey/blob/cisskey/src/client/widgets/post-form.vue) を参考に修正しました。