### PR TITLE
ActivityPub にデータを送信するのを無効化

### DIFF
--- a/src/queue/processors/deliver.ts
+++ b/src/queue/processors/deliver.ts
@@ -13,6 +13,8 @@ const logger = new Logger('deliver');
 let latest: string | null = null;
 
 export default async (job: Bull.Job) => {
+	if (true) return 'skip (unsupported)';
+
 	const { host } = new URL(job.data.to);
 
 	// ブロックしてたら中断


### PR DESCRIPTION
## Summary

未検証ですがとりあえず

内部のデータが外部に送信されるのは全てここ経由なはずなので、何もしないようにして外部にデータが漏れるのを防ぎます。