### PR TITLE
リモートユーザーを一切解決しないように

### DIFF
--- a/src/remote/resolve-user.ts
+++ b/src/remote/resolve-user.ts
@@ -36,6 +36,9 @@ export async function resolveUser(username: string, host: string | null, option?
 		});
 	}
 
+	// リモートユーザーの解決を一切しないように
+	throw new Error('disable resolve remote user');
+
 	const user = await Users.findOne({ usernameLower, host }, option) as IRemoteUser;
 
 	const acctLower = `${usernameLower}@${host}`;

--- a/src/server/api/endpoints/ap/show.ts
+++ b/src/server/api/endpoints/ap/show.ts
@@ -79,6 +79,9 @@ async function fetchAny(uri: string) {
 		}
 	}
 
+	// リモートのユーザー、投稿情報は一切取得しないように
+	return null;
+
 	// ブロックしてたら中断
 	const meta = await fetchMeta();
 	if (meta.blockedHosts.includes(extractDbHost(uri))) return null;


### PR DESCRIPTION
## Summary

Misskeyインスタンスに対して、`/@example@example.com`などとアクセスしたときなどでリモートユーザーが解決されないようにします。

解決されユーザーがDBに追加されるのを防ぐことで、メンション時のサジェストでリモートユーザーが表示されないようになるはずです。