### PR TITLE
チャンネルページから別チャンネルページに移動するとタイムラインが変更されない

### DIFF
--- a/src/client/pages/channel.vue
+++ b/src/client/pages/channel.vue
@@ -22,7 +22,7 @@
 
 	<XPostForm :channel="channel" class="post-form _content _panel _vMargin" fixed v-if="this.$store.getters.isSignedIn"/>
 
-	<XTimeline class="_content _vMargin" src="channel" :channel="channelId" @before="before" @after="after"/>
+	<XTimeline class="_content _vMargin" src="channel" :key="channelId" :channel="channelId" @before="before" @after="after"/>
 </div>
 </template>
 


### PR DESCRIPTION
## Summary

XTimeline は channel などのプロパティが変わっても作成時の状態から変化しないようです。 `key` を指定することで、チャンネルが変わった場合に XTimeline コンポーネント自体が作り直されるようにして解決しました。

これはホームでも同じことをしてるみたい (https://github.com/syuilo/misskey/blob/7660839e40cb40ac80c26c5548686f9e37ced5fc/src/client/pages/timeline.vue#L10)

Resolves #101