### PR TITLE
一部条件においてWebhookの設定を適用できないバグを修正

### DIFF
--- a/src/client/pages/settings/webhook.vue
+++ b/src/client/pages/settings/webhook.vue
@@ -102,16 +102,16 @@ export default defineComponent({
 		async save(notify?: boolean) {
 			await os.api('i/update', {
 				enableWebhookNotification: this.enableWebhook,
-				webhookUrl: this.url.trim() || null,
+				webhookUrl: this.url?.trim() || null,
 				webhookType: this.type,
-				webhookSecret: this.secret.trim() || null
+				webhookSecret: this.secret?.trim() || null
 			}).then(() => {
 				this.changed = false;
 
 				this.$i.enableWebhookNotification = this.enableWebhook;
-				this.$i.webhookUrl = this.url.trim() || null;
+				this.$i.webhookUrl = this.url?.trim() || null;
 				this.$i.webhookType = this.type;
-				this.$i.webhookSecret = this.secret.trim() || null;
+				this.$i.webhookSecret = this.secret?.trim() || null;
 
 				if (notify) {
 					os.dialog({


### PR DESCRIPTION
## Summary

Webhook通知の設定で、シークレットやURLが空欄だと設定を適用できないバグを修正しました。

原因は、それらが空欄、nullになることの想定忘れです。