### PR TITLE
Source Map 有効化

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -167,6 +167,6 @@ module.exports = {
 	experiments: {
 		topLevelAwait: true
 	},
-	devtool: false, //'source-map',
+	devtool: 'source-map',
 	mode: isProduction ? 'production' : 'development'
 };


### PR DESCRIPTION
## Summary

Production 環境でバグが発生した場合に調査する時に、ビルドされたコードだとしんどいことがあるので Source Map を有効にしてみる。設定項目については https://webpack.js.org/configuration/devtool/ を参照。

軽く思いつく懸念事項としては

* ビルドが重たくなる→試した限りだと許容範囲だった
* 利用者がソースコード読める→ OSS なので関係無い
* クライアントの挙動が変わる可能性がある(?)→多分無いはず

といった感じで、特に大きな問題はなくバグの修正がしやすくなるほうが大事だと思ったので試してみて、何か問題が発生したらその時また考える。
