### PR TITLE
Add version suffix to Docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,7 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
+          build-args: VERSION_SUFFIX=-${GITHUB_SHA::7}
       -
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:14.15.1-alpine AS base
 
 ENV NODE_ENV=production
+ARG VERSION_SUFFIX
 
 WORKDIR /misskey
 
@@ -24,6 +25,7 @@ RUN apk add --no-cache \
 COPY package.json yarn.lock ./
 RUN yarn install
 COPY . ./
+RUN sed -i'' -E 's/'$'\t''"version": "(.*)",/'$'\t''"version": "\1'"$VERSION_SUFFIX"'",/' package.json
 RUN yarn build
 
 FROM base AS runner
@@ -37,5 +39,6 @@ ENTRYPOINT ["/sbin/tini", "--"]
 COPY --from=builder /misskey/node_modules ./node_modules
 COPY --from=builder /misskey/built ./built
 COPY . ./
+RUN sed -i'' -E 's/'$'\t''"version": "(.*)",/'$'\t''"version": "\1'"$VERSION_SUFFIX"'",/' package.json
 
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
GitHub Actions で Docker イメージを作って GitHub Container Registry に push する仕組むを組んでいて、そのときにバージョン部分にコミットのハッシュを入れるようにします。これがないと、同一リリースと認識されるとクライアントがキャッシュを更新してくれないのでうまく更新ができなくなります。今までは手動でやっていたので自動化できてサーバーでは GitHub Container Registry から pull するだけで済みます。