### PR TITLE
Object Storage 改善

### DIFF
--- a/src/server/file/send-drive-file.ts
+++ b/src/server/file/send-drive-file.ts
@@ -4,6 +4,7 @@ import * as rename from 'rename';
 import * as tmp from 'tmp';
 import * as fs from 'fs';
 import { serverLogger } from '..';
+import { fetchMeta } from '../../misc/fetch-meta';
 import { contentDisposition } from '../../misc/content-disposition';
 import { DriveFiles } from '../../models';
 import { InternalStorage } from '../../services/drive/internal-storage';
@@ -11,6 +12,7 @@ import { downloadUrl } from '../../misc/download-url';
 import { detectType } from '../../misc/get-file-info';
 import { convertToJpeg, convertToPngOrJpeg } from '../../services/drive/image-processor';
 import { GenerateVideoThumbnail } from '../../services/drive/generate-video-thumbnail';
+import { getS3 } from '../../services/drive/s3';
 
 const assets = `${__dirname}/../../server/file/assets/`;
 
@@ -89,6 +91,18 @@ export default async function(ctx: Koa.Context) {
 			} finally {
 				cleanup();
 			}
+			return;
+		}
+
+		const meta = await fetchMeta();
+		if (meta.useObjectStorage) {
+			const s3 = getS3(meta);
+			const url = s3.getSignedUrl('getObject', {
+				Bucket: meta.objectStorageBucket,
+				Key: meta.objectStoragePrefix + key,
+				Expires: 60 * 10,
+			});
+			ctx.redirect(url);
 			return;
 		}
 

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -53,7 +53,7 @@ async function save(file: DriveFile, path: string, name: string, type: string, h
 			|| `${ meta.objectStorageUseSSL ? 'https' : 'http' }://${ meta.objectStorageEndpoint }${ meta.objectStoragePort ? `:${meta.objectStoragePort}` : '' }/${ meta.objectStorageBucket }`;
 
 		// for original
-		const key = `${meta.objectStoragePrefix}/${uuid()}${ext}`;
+		const key = `${uuid()}${ext}`;
 		const url = `${ baseUrl }/${ key }`;
 
 		// for alts
@@ -70,7 +70,7 @@ async function save(file: DriveFile, path: string, name: string, type: string, h
 		];
 
 		if (alts.webpublic) {
-			webpublicKey = `${meta.objectStoragePrefix}/webpublic-${uuid()}.${alts.webpublic.ext}`;
+			webpublicKey = `webpublic-${uuid()}.${alts.webpublic.ext}`;
 			webpublicUrl = `${ baseUrl }/${ webpublicKey }`;
 
 			logger.info(`uploading webpublic: ${webpublicKey}`);
@@ -78,7 +78,7 @@ async function save(file: DriveFile, path: string, name: string, type: string, h
 		}
 
 		if (alts.thumbnail) {
-			thumbnailKey = `${meta.objectStoragePrefix}/thumbnail-${uuid()}.${alts.thumbnail.ext}`;
+			thumbnailKey = `thumbnail-${uuid()}.${alts.thumbnail.ext}`;
 			thumbnailUrl = `${ baseUrl }/${ thumbnailKey }`;
 
 			logger.info(`uploading thumbnail: ${thumbnailKey}`);
@@ -246,7 +246,7 @@ async function upload(key: string, stream: fs.ReadStream | Buffer, type: string,
 
 	const params = {
 		Bucket: meta.objectStorageBucket,
-		Key: key,
+		Key: meta.objectStoragePrefix + key,
 		Body: stream,
 		ContentType: type,
 		CacheControl: 'max-age=31536000, immutable',

--- a/src/services/drive/delete-file.ts
+++ b/src/services/drive/delete-file.ts
@@ -128,7 +128,7 @@ export async function deleteObjectStorageFile(key: string) {
 
 	await s3.deleteObject({
 		Bucket: meta.objectStorageBucket!,
-		Key: key
+		Key: meta.objectStoragePrefix + key
 	}).promise();
 }
 

--- a/src/tools/upload-files.ts
+++ b/src/tools/upload-files.ts
@@ -1,0 +1,103 @@
+import * as fs from 'fs';
+import * as S3 from 'aws-sdk/clients/s3';
+import * as rename from 'rename';
+import { getRepository } from 'typeorm';
+import { initDb } from '../db/postgre';
+import { contentDisposition } from '../misc/content-disposition';
+import { detectType } from '../misc/get-file-info';
+import { InternalStorage } from '../services/drive/internal-storage';
+import { DriveFile } from '../models/entities/drive-file';
+
+async function main(lastId) {
+	await initDb();
+	const DriveFiles = getRepository(DriveFile);
+	const s3 = getS3();
+
+	while (true) {
+		const query = DriveFiles.createQueryBuilder('file');
+		query.where('file.storedInternal = :storedInternal', { storedInternal: true });
+		if (lastId) {
+			query.andWhere('file.id > :lastId', { lastId: lastId });
+		}
+		query.orderBy('file.id', 'ASC').limit(20);
+		const files = await query.getMany();
+		if (files.length === 0) return;
+		for (const file of files) {
+			console.log(`Uploading ${file.id}`);
+			await uploadFile(s3, file);
+			lastId = file.id;
+		}
+	}
+}
+
+function getS3() {
+	return new S3({
+		endpoint: process.env['OBJECT_STORAGE_ENDPOINT'],
+		accessKeyId: process.env['AWS_ACCESS_KEY_ID'],
+		secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'],
+		region: process.env['AWS_REGION'],
+		sslEnabled: true,
+		s3ForcePathStyle: process.env['OBJECT_STORAGE_FORCE_PATH_STYLE'] == '1',
+	});
+}
+
+async function uploadFile(s3: S3, file: DriveFile) {
+	const uploads = [
+		upload(s3, file, file.accessKey)
+	];
+	if (file.webpublicUrl) {
+		uploads.push(upload(s3, file, file.webpublicAccessKey, '-web'));
+	}
+	if (file.thumbnailUrl) {
+		uploads.push(upload(s3, file, file.thumbnailAccessKey, '-thumb'));
+	}
+	await Promise.all(uploads);
+}
+
+async function upload(s3: S3, file: DriveFile, key: string, suffix?: string) {
+	try {
+		await s3.headObject({
+			Bucket: process.env['OBJECT_STORAGE_BUCKET'],
+			Key: process.env['OBJECT_STORAGE_PREFIX'] + key,
+		}).promise();
+		console.log(`Object "${key}" is already exists. Skipping upload...`);
+	} catch (err) {
+		if (err.code !== 'NotFound') throw err;
+	}
+
+	let filename = file.name;
+	let type = file.type;
+
+	if (suffix) {
+		const { mime, ext } = await detectType(InternalStorage.resolvePath(key));
+		type = mime;
+		filename = rename(filename, {
+			suffix: suffix,
+			extname: ext ? `.${ext}` : undefined
+		}).toString();
+	}
+	if (type === 'image/apng') type = 'image/png';
+
+	const upload = s3.upload({
+		Bucket: process.env['OBJECT_STORAGE_BUCKET'],
+		Key: process.env['OBJECT_STORAGE_PREFIX'] + key,
+		Body: fs.createReadStream(InternalStorage.resolvePath(key)),
+		ContentType: type,
+		CacheControl: 'max-age=31536000, immutable',
+		ContentDisposition: contentDisposition('inline', filename),
+	}, {
+		partSize: 8 * 1024 * 1024,
+	});
+
+	return await upload.promise();
+}
+
+const args = process.argv.slice(2);
+
+main(args[0]).then(() => {
+	console.log('Success');
+	process.exit(0);
+}).catch(e => {
+	console.error(`Error: ${e.message || e}`);
+	process.exit(1);
+});


### PR DESCRIPTION
Object Storage に移行するためにいくつか変更入れました

* 内部ストレージを使っているのを` Object Storage に切り替えるために既存ファイルのアップロードスクリプトを作成
* ファイルの key に Object Storage の Prefix が含まれないように変更
  * 内部ストレージから切り替えたものについて、 Prefix が含まれてないので削除等の処理で不都合になるため
  * 同時に Prefix と key の間に `/` を入れないようにも変更 (Object Storage で `/` を delimiter として使うとは限らない & 空の場合の処理が難しいため)
* `/files/` のパスに内部に保存されてないファイルが来た場合に Signed URL にリダイレクトするように変更
  * Object Storage の Base URL を `https://misskey.example.com/files` のようにする想定
  * ファイル自体をパブリックにせず、前段 Proxy の認証が通さないとファイルにアクセスできないようにするため