### PR TITLE
リアクション時にスコアが狂う問題の修正

### DIFF
--- a/src/services/note/reaction/create.ts
+++ b/src/services/note/reaction/create.ts
@@ -49,7 +49,6 @@ export default async (user: { id: User['id']; host: User['host']; }, note: Note,
 	await Notes.createQueryBuilder().update()
 		.set({
 			reactions: () => sql,
-			score: () => '"score" + 1'
 		})
 		.where('id = :id', { id: note.id })
 		.execute();


### PR DESCRIPTION
リアクションつけた時のノートのスコアが増えやすい問題を修正します。


### 想定された挙動

* その人がそのノートにはじめてリアクションをつけた際に、ノートのスコアを 1 増加させる
* その人がノートに複数のリアクションをつけたとしても、ノートにスコアを増加させない
* その人がつけたリアクションがすべて消えた際に、ノートのスコアを 1 減少させる

### 実際の挙動

* その人がそのノートにはじめてリアクションをつけた際に、ノートのスコアが 2 増加される
* 2個目以降のリアクションをつけた場合にもスコアが 1 増加される
* このため、リアクションを複数つけたり、つけて消してを繰り返した場合にスコアが異常に増える

### 原因

* #29 で複数リアクションに対応した際に、複数リアクションでスコアが増加されないように条件を追加していた (Misskey 本家との差分になる)
* #118 で更新する際に Misskey 本家側でその部分が変更された a4a9b8707d2d8100e3601679d479dd3b13e73c9a
  * 差分的にコンフリクトが発生するはずだが、多分見逃してスコアを増加される処理が2つになっていた

### デプロイ後の注意点

これ修正を入れる前に行われたスコアは異常なままになっちゃいますが、再計算させるのも面倒なのでそのままにします。
スコアはハイライトの計算くらいにしか使われていないはずで、ハイライトは最長3日前までしか出ないのでデプロイ3日後にはほぼ正常な状態になるはずです。