### PR TITLE
Update twemoji base URL to use jsdelivr

### DIFF
--- a/src/misc/twemoji-base.ts
+++ b/src/misc/twemoji-base.ts
@@ -1,1 +1,1 @@
-export const twemojiSvgBase = 'https://twemoji.maxcdn.com/v/latest/svg';
+export const twemojiSvgBase = 'https://cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg';


### PR DESCRIPTION
https://www.stackpath.com/blog/maxcdn-and-securecdn-are-retiring-heres-what-it-means-for-you いわく `twemoji.maxcdn.com` が 31 日で使えなくなりそうなので jsdelivr を使うように変更します。