### PR TITLE
v13 にマイグレーションの追加

### DIFF
--- a/packages/backend/migration/1598288528357-multiple-reactions.js
+++ b/packages/backend/migration/1598288528357-multiple-reactions.js
@@ -1,0 +1,16 @@
+export class multipleReactions1598288528357 {
+    name = 'multipleReactions1598288528357'
+
+    async up(queryRunner) {
+        await queryRunner.query(`DROP INDEX "IDX_ad0c221b25672daf2df320a817"`);
+        await queryRunner.query(`CREATE INDEX "IDX_ad0c221b25672daf2df320a817" ON "note_reaction" ("userId", "noteId") `);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_a7751b74317122d11575bff31c" ON "note_reaction" ("userId", "noteId", "reaction") `);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`DROP INDEX "IDX_a7751b74317122d11575bff31c"`);
+        await queryRunner.query(`DROP INDEX "IDX_ad0c221b25672daf2df320a817"`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_ad0c221b25672daf2df320a817" ON "note_reaction" ("userId", "noteId") `);
+    }
+
+}

--- a/packages/backend/migration/1598579359831-reaction-timestamps.js
+++ b/packages/backend/migration/1598579359831-reaction-timestamps.js
@@ -1,0 +1,12 @@
+export class reactionTimestamps1598579359831 {
+    name = 'reactionTimestamps1598579359831'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "note" ADD "reactionTimestamps" jsonb NOT NULL DEFAULT '{}'`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "note" DROP COLUMN "reactionTimestamps"`);
+    }
+
+}

--- a/packages/backend/migration/1598986920665-WebhookNotification.js
+++ b/packages/backend/migration/1598986920665-WebhookNotification.js
@@ -1,0 +1,16 @@
+export class WebhookNotification1598986920665 {
+    name = 'WebhookNotification1598986920665'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "user_profile" ADD "enableWebhookNotification" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ADD "webhookUrl" character varying(256)`);
+        await queryRunner.query(`CREATE INDEX "IDX_f0c7bece0ceafad7b18c34cbb8" ON "user_profile" ("enableWebhookNotification") `);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`DROP INDEX "IDX_f0c7bece0ceafad7b18c34cbb8"`);
+        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "webhookUrl"`);
+        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "enableWebhookNotification"`);
+    }
+
+}

--- a/packages/backend/migration/1599309954647-webhook_instance_setting.js
+++ b/packages/backend/migration/1599309954647-webhook_instance_setting.js
@@ -1,0 +1,12 @@
+export class webhookInstanceSetting1599309954647 {
+    name = 'webhookInstanceSetting1599309954647'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "meta" ADD "enableWebhookNotification" boolean NOT NULL DEFAULT false`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "enableWebhookNotification"`);
+    }
+
+}

--- a/packages/backend/migration/1602079745193-add_featuredNgWord.js
+++ b/packages/backend/migration/1602079745193-add_featuredNgWord.js
@@ -1,0 +1,12 @@
+export class addFeaturedNgWord1602079745193 {
+    name = 'addFeaturedNgWord1602079745193'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "meta" ADD "featuredNgWords" character varying(256) array NOT NULL DEFAULT '{}'::varchar[]`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "meta" DROP COLUMN "featuredNgWords"`);
+    }
+
+}

--- a/packages/backend/migration/1603003666233-add_webhookType.js
+++ b/packages/backend/migration/1603003666233-add_webhookType.js
@@ -1,0 +1,14 @@
+export class addWebhookType1603003666233 {
+    name = 'addWebhookType1603003666233'
+
+    async up(queryRunner) {
+        await queryRunner.query(`CREATE TYPE "user_profile_webhooktype_enum" AS ENUM('slack', 'bot')`);
+        await queryRunner.query(`ALTER TABLE "user_profile" ADD "webhookType" "user_profile_webhooktype_enum" NOT NULL DEFAULT 'slack'`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "webhookType"`);
+        await queryRunner.query(`DROP TYPE "user_profile_webhooktype_enum"`);
+    }
+
+}

--- a/packages/backend/migration/1603256087263-add_webhookSecret_column..js
+++ b/packages/backend/migration/1603256087263-add_webhookSecret_column..js
@@ -1,0 +1,12 @@
+export class addWebhookSecretColumn1603256087263 {
+    name = 'addWebhookSecretColumn1603256087263'
+
+    async up(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "user_profile" ADD "webhookSecret" character varying(128)`);
+    }
+
+    async down(queryRunner) {
+        await queryRunner.query(`ALTER TABLE "user_profile" DROP COLUMN "webhookSecret"`);
+    }
+
+}


### PR DESCRIPTION
#124 のために、現在の cisskey ブランチ (v12 ベースのもの) で追加した DB マイグレーションをすべて追加し直します。
一部のマイグレーションの変更はもう不要になるカラム追加なので、追加しなくても問題無く動作するはずですが、本番環境の DB と差異が発生しないようにするためにも全部追加しておきます。