### PR TITLE
リアクション再ソートの v13 対応

### DIFF
--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -279,6 +279,14 @@ export class NoteEntityService implements OnModuleInit {
 			.filter(x => x.startsWith(':') && x.includes('@') && !x.includes('@.')) // リモートカスタム絵文字のみ
 			.map(x => this.reactionService.decodeReaction(x).reaction.replaceAll(':', ''));
 
+		const reactions = Object.keys(note.reactions)
+			.filter(k => note.reactions[k] > 0)
+			.sort((a, b) => (note.reactionTimestamps[a] || 0) - (note.reactionTimestamps[b] || 0))
+			.reduce<Record<string, number>>((o, k) => {
+				o[k] = note.reactions[k];
+				return o;
+			}, {});
+
 		const packed: Packed<'Note'> = await awaitAll({
 			id: note.id,
 			createdAt: note.createdAt.toISOString(),
@@ -293,7 +301,7 @@ export class NoteEntityService implements OnModuleInit {
 			visibleUserIds: note.visibility === 'specified' ? note.visibleUserIds : undefined,
 			renoteCount: note.renoteCount,
 			repliesCount: note.repliesCount,
-			reactions: this.reactionService.convertLegacyReactions(note.reactions),
+			reactions: this.reactionService.convertLegacyReactions(reactions),
 			reactionEmojis: this.customEmojiService.populateEmojis(reactionEmojiNames, host),
 			emojis: host != null ? this.customEmojiService.populateEmojis(note.emojis, host) : undefined,
 			tags: note.tags.length > 0 ? note.tags : undefined,

--- a/packages/backend/src/models/entities/Note.ts
+++ b/packages/backend/src/models/entities/Note.ts
@@ -102,6 +102,11 @@ export class Note {
 	})
 	public reactions: Record<string, number>;
 
+	@Column('jsonb', {
+		default: {}
+	})
+	public reactionTimestamps: Record<string, number>;
+
 	/**
 	 * public ... 公開
 	 * home ... ホームタイムライン(ユーザーページのタイムライン含む)のみに流す


### PR DESCRIPTION
#124 のために #45 で実装したリアクションをつけた順でソートする機能を再実装します。

動作確認はまだしていないです。