### PR TITLE
ActivityPub 無効化の v13 対応

### DIFF
--- a/packages/backend/src/core/UtilityService.ts
+++ b/packages/backend/src/core/UtilityService.ts
@@ -27,7 +27,8 @@ export class UtilityService {
 	@bindThis
 	public isBlockedHost(blockedHosts: string[], host: string | null): boolean {
 		if (host == null) return false;
-		return blockedHosts.some(x => `.${host.toLowerCase()}`.endsWith(`.${x}`));
+		return !isSelfHost(host); // Disable federation entirely
+		//return blockedHosts.some(x => `.${host.toLowerCase()}`.endsWith(`.${x}`));
 	}
 
 	@bindThis

--- a/packages/backend/src/core/UtilityService.ts
+++ b/packages/backend/src/core/UtilityService.ts
@@ -27,7 +27,7 @@ export class UtilityService {
 	@bindThis
 	public isBlockedHost(blockedHosts: string[], host: string | null): boolean {
 		if (host == null) return false;
-		return !isSelfHost(host); // Disable federation entirely
+		return !this.isSelfHost(host); // Disable federation entirely
 		//return blockedHosts.some(x => `.${host.toLowerCase()}`.endsWith(`.${x}`));
 	}
 


### PR DESCRIPTION
#124 のため #99, #100 で行っていた ActivityPub の無効化を v13 にも行いました。
全てのホストをブロックしていることにすることで、 1 箇所の変更で済むようにしています。