### PR TITLE
失敗しているテストの修正

### DIFF
--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -172,7 +172,7 @@ export class NoteEntityService implements OnModuleInit {
 	@bindThis
 	private async populateMyReactions(note: Note, meId: User['id'], _hint_?: {
 		myReactions: Map<Note['id'], NoteReaction[] | null>;
-	}) {
+	}): Promise<string[]> {
 		if (_hint_?.myReactions) {
 			const reactions = _hint_.myReactions.get(note.id);
 			if (reactions) {
@@ -183,7 +183,7 @@ export class NoteEntityService implements OnModuleInit {
 
 		// パフォーマンスのためノートが作成されてから1秒以上経っていない場合はリアクションを取得しない
 		if (note.createdAt.getTime() + 1000 > Date.now()) {
-			return undefined;
+			return [];
 		}
 
 		const reactions = await this.noteReactionsRepository.findBy({
@@ -356,9 +356,7 @@ export class NoteEntityService implements OnModuleInit {
 
 				poll: note.hasPoll ? this.populatePoll(note, meId) : undefined,
 
-				...(meId ? {
-					myReactions: this.populateMyReactions(note, meId, options?._hint_)
-				} : {}),
+				myReactions: meId ? this.populateMyReactions(note, meId, options?._hint_) : [],
 			} : {}),
 		});
 

--- a/packages/backend/test/e2e/endpoints.ts
+++ b/packages/backend/test/e2e/endpoints.ts
@@ -235,7 +235,7 @@ describe('Endpoints', () => {
 			assert.strictEqual(res.status, 204);
 		});
 
-		test('二重にリアクションすると上書きされる', async () => {
+		test('複数リアクションできる', async () => {
 			const bobPost = await post(bob, { text: 'hi' });
 
 			await api('/notes/reactions/create', {
@@ -255,7 +255,7 @@ describe('Endpoints', () => {
 			}, alice);
 
 			assert.strictEqual(resNote.status, 200);
-			assert.deepStrictEqual(resNote.body.reactions, { '🚀': 1 });
+			assert.deepStrictEqual(resNote.body.reactions, { "🥰": 1, "🚀": 1 });
 		});
 
 		test('存在しない投稿にはリアクションできない', async () => {


### PR DESCRIPTION
* ノート直後に取得すると `myReactions` フィールドが undefined で存在せず、少し立ってから取得すると空リストになっていたのを修正
* 重複リアクションを許可しているため、それに関するテストを変更